### PR TITLE
Improve json section

### DIFF
--- a/docs/scenarios/json.rst
+++ b/docs/scenarios/json.rst
@@ -26,7 +26,7 @@ and can now be used as a normal dictionary:
     print(parsed_json['first_name'])
     "Guido"
 
-You can also convert a the following to JSON:
+You can also convert the following to JSON:
 
 .. code-block:: python
 
@@ -43,6 +43,14 @@ You can also convert a the following to JSON:
 simplejson
 ----------
 
-`simplejson <https://simplejson.readthedocs.org/en/latest/>`_ is the externally maintained development version of the json library.
+The JSON library was added to Python in version 2.6. If you're using an earlier version of Python, the `simplejson <https://simplejson.readthedocs.org/en/latest/>`_ library is available via PyPI.
 
-simplejson mimics the json standard library, it is available so that developers that use an older version of python can use the latest features available in the json lib.
+simplejson mimics the json standard library. It is available so that developers that use older versions of Python can use the latest features available in the json lib.
+
+You can start using simplejson when the json library is not available by importing simplejson under a different name:
+
+.. code-block:: python
+    
+    import simplejson as json
+
+After importing simplejson as json, the above examples will all work as if you were using the standard json library.

--- a/docs/scenarios/json.rst
+++ b/docs/scenarios/json.rst
@@ -39,6 +39,36 @@ You can also convert the following to JSON:
     print(json.dumps(d))
     '{"first_name": "Guido", "last_name": "Rossum", "titles": ["BDFL", "Developer"]}'
 
+Working with File Objects
+-------------------------
+
+We can also load a JSON file by using ``json.load`` instead of ``json.loads``:
+
+.. code-block:: python
+
+    import json
+    
+    with file('path/to/file.json') as f:
+        loaded_json = json.load(f)
+    
+    print(loaded_json)  # {'first_name': 'Ada', 'last_name': 'Lovelace'}
+
+Here's an example of writing directly to a file by using ``json.dump`` instead of ``json.dumps``:
+
+.. code-block:: python
+
+    import json
+
+    my_data = {
+        'name': 'Alan Turing',
+        'played_by': 'Benedict Cumberbatch'
+    }
+
+    with file('path/to/file.json', 'w') as f:
+        json.dump(my_data, f)
+
+``path/to/file.json`` now contains a JSON representation of the my_data dictionary.
+
 
 simplejson
 ----------

--- a/docs/scenarios/json.rst
+++ b/docs/scenarios/json.rst
@@ -39,36 +39,6 @@ You can also convert the following to JSON:
     print(json.dumps(d))
     '{"first_name": "Guido", "last_name": "Rossum", "titles": ["BDFL", "Developer"]}'
 
-Working with File Objects
--------------------------
-
-We can also load a JSON file by using ``json.load`` instead of ``json.loads``:
-
-.. code-block:: python
-
-    import json
-    
-    with file('path/to/file.json') as f:
-        loaded_json = json.load(f)
-    
-    print(loaded_json)  # {'first_name': 'Ada', 'last_name': 'Lovelace'}
-
-Here's an example of writing directly to a file by using ``json.dump`` instead of ``json.dumps``:
-
-.. code-block:: python
-
-    import json
-
-    my_data = {
-        'name': 'Alan Turing',
-        'played_by': 'Benedict Cumberbatch'
-    }
-
-    with file('path/to/file.json', 'w') as f:
-        json.dump(my_data, f)
-
-``path/to/file.json`` now contains a JSON representation of the my_data dictionary.
-
 
 simplejson
 ----------

--- a/docs/scenarios/json.rst
+++ b/docs/scenarios/json.rst
@@ -1,7 +1,7 @@
 JSON
 ====
 
-The `json <https://docs.python.org/2/library/json.html>`_ library can parse JSON from strings or files. When parsing, the library converts the JSON into a Python dictionary or list. It can also parse Python dictionaries or lists into JSON strings.
+The `json <https://docs.python.org/2/library/json.html>`_ library can parse JSON from strings or files. The library parses JSON into a Python dictionary or list. It can also convert Python dictionaries or lists into JSON strings.
 
 Parsing JSON
 ------------


### PR DESCRIPTION
I've added the following to the JSON section:

* How to use simplejson in place of json in older versions of Python
* How to load and save JSON from/to file objects instead of strings

I've also reworded the intro paragraph a little and cleaned up the language of the simplejson paragraph.

Please take a look and tell me what you think! Thanks.