### PR TITLE
Update imaging.rst

### DIFF
--- a/docs/scenarios/imaging.rst
+++ b/docs/scenarios/imaging.rst
@@ -21,7 +21,7 @@ Installation
 
 Before installing Pillow, you'll have to install Pillow's prerequisites. Find
 the instructions for your platform
-`here <https://pypi.python.org/pypi/Pillow/2.1.0#platform-specific-instructions>`_.
+`here <http://pillow.readthedocs.org/installation.html>`_.
 
 After that, it's straightforward:
 


### PR DESCRIPTION
Refer to official Pillow documentation instead of outdated release README; installation instructions were relocated from ``README.rst`` to docs/ sometime after 2.8.1 was released. And docs have been hosted on RTD for quite some time.