### PR TITLE
reflect unification of python in emacs.

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -100,10 +100,6 @@ it can be some work to wire up correctly. A good start if you're already an
 Emacs user is `Python Programming in Emacs`_ at EmacsWiki.
 
 1. Emacs itself comes with a Python mode.
-2. Python ships with an alternate version:
-   `python-mode.el <https://launchpad.net/python-mode>`_
-3. Fabián Ezequiel Gallina's `python.el <https://github.com/fgallina/python.el>`_
-   provides nice functionality and behavior out of the box
 
 .. _Python Programming in Emacs: http://emacswiki.org/emacs/PythonProgrammingInEmacs
 


### PR DESCRIPTION
Current emacs no longer has ambiguous python.el. Gallina version is now the blessed standard.

