### PR TITLE
Fixed a broken PEP acceptance workflow link.

### DIFF
--- a/docs/intro/community.rst
+++ b/docs/intro/community.rst
@@ -65,7 +65,7 @@ Submitting a PEP
 
  Here's an overview of the PEP acceptance workflow:
 
- .. image:: http://www.python.org/dev/peps/pep-0001/pep-0001-1.png
+ .. image:: https://www.python.org/m/dev/peps/pep-0001/pep-0001-1.png
 
 
 Python Conferences


### PR DESCRIPTION
The image for a PEP acceptance workflow was 404. I took a valid link directly from [https://www.python.org/dev/peps/pep-0001/](https://www.python.org/dev/peps/pep-0001/).