### PR TITLE
Contribute link on sidebar fixed

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -23,7 +23,7 @@
   This guide is the result of the collaboration of
   <a href="https://github.com/kennethreitz/python-guide/graphs/contributors">135+ people</a>
   around the world, and your contributions
-  <a href="http://docs.python-guide.org/en/latest/notes/contribute.html">are welcome</a>!
+  <a href="http://docs.python-guide.org/en/latest/notes/contribute/">are welcome</a>!
 </p>
 
 


### PR DESCRIPTION
The link for contributing - http://docs.python-guide.org/en/latest/notes/contribute.html is broken. Fixed it to point to correct link.
