### PR TITLE
Un-hyphenating best practice in multiple files

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -9,7 +9,7 @@ Hitchhiker's Guide to Python
 be done.**
 
 This guide is currently under heavy development. This opinionated guide
-exists to provide both novice and expert Python developers a best-practice
+exists to provide both novice and expert Python developers a best practice
 handbook to the installation, configuration, and usage of Python on a daily
 basis.
 

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -1,6 +1,6 @@
 <h1>Python Guide.</h1>
 <p>
-  This opinionated guide exists to provide both novice and expert Python developers a best-practice handbook to the installation, configuration, and usage of Python on a daily basis.
+  This opinionated guide exists to provide both novice and expert Python developers a best practice handbook to the installation, configuration, and usage of Python on a daily basis.
 </p>
 
 <h3>Get Updates</h3>

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -1,6 +1,6 @@
 <h1><a href="http://python-guide.org">Python Guide.</a></h1>
 <p>
-  This opinionated guide exists to provide both novice and expert Python developers a best-practice handbook to the installation, configuration, and usage of Python on a daily basis.
+  This opinionated guide exists to provide both novice and expert Python developers a best practice handbook to the installation, configuration, and usage of Python on a daily basis.
 </p>
 
 <h3>Get Updates</h3>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Welcome to The Hitchhiker's Guide to Python.
 `fork us on GitHub <https://github.com/kennethreitz/python-guide>`_!
 
 This *opinionated* guide exists to provide both novice and expert Python
-developers a best-practice handbook to the installation, configuration, and
+developers a best practice handbook to the installation, configuration, and
 usage of Python on a daily basis.
 
 .. include:: contents.rst.inc

--- a/docs/intro/duction.rst
+++ b/docs/intro/duction.rst
@@ -61,7 +61,7 @@ Purpose
 ~~~~~~~
 
 The Hitchhiker's Guide to Python exists to provide both novice and expert
-Python developers a best-practice handbook to the installation, configuration,
+Python developers a best practice handbook for the installation, configuration,
 and usage of Python on a daily basis.
 
 


### PR DESCRIPTION
Best practice should not be hyphenated, I removed multiple instances where it was, I intentionally left out `_server-best-practices-ref:` (Line 177, docs/scenarios/web.rst).

Sources to support the change:
[Oxford dictionary, English](http://www.oxforddictionaries.com/definition/english/best-practice)
[Oxford dictionary, American English](http://www.oxforddictionaries.com/definition/american_english/best-practice)
[Wikipedia](https://en.wikipedia.org/wiki/Best_practice)