### PR TITLE
Fix link to pip vs easy_install comparison

### DIFF
--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -73,7 +73,7 @@ software over a network (usually the Internet) with a single command
 capability to your own Python software with very little work.
 
 ``pip`` is a tool for easily installing and managing Python packages,
-that is recommended over ``easy_install``. It is superior to ``easy_install`` in `several ways <https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install.html#pip-vs-easy-install>`_,
+that is recommended over ``easy_install``. It is superior to ``easy_install`` in `several ways <https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install>`_,
 and is actively maintained.
 
 


### PR DESCRIPTION
The link on ```several ways``` specified in section http://docs.python-guide.org/en/latest/starting/install/osx/#setuptools-pip is broken.

Fixed with https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install