### PR TITLE
Add a section for pyenv

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -232,7 +232,32 @@ For example, you can work on a project which requires Django 1.3 while also
 maintaining a project which requires Django 1.0.
 
 To start using and see more information:
-`Virtual Environments <http://github.com/kennethreitz/python-guide/blob/master/docs/dev/virtualenvs.rst>`_ docs. 
+`Virtual Environments <http://github.com/kennethreitz/python-guide/blob/master/docs/dev/virtualenvs.rst>`_ docs.
+
+
+pyenv
+-----
+
+`pyenv <https://github.com/yyuu/pyenv>`_ is a tool to allow multiple versions
+of the Python interpreter to be installed at the same time.  This solves the
+problem of having different projects requiring different versions of Python.
+For example, it becomes very easy to install Python 2.7 for compatibility in
+an one project, whilst still using Python 3.4 as the default interpreter.
+pyenv isn't just limited to the CPython versions - it will also install PyPy,
+anaconda, miniconda, stackless, jython, and ironpython interpreters.
+
+pyenv works by filling a ``shims`` directory with fake versions of the Python
+interpreter (plus other tools like ``pip`` and ``2to3``).  When the system
+looks for a program named ``python``, it looks inside the ``shims`` directory
+first, and uses the fake version, which in turn passes the command on to
+pyenv.  pyenv then works out which version of Python should be run based on
+environment variables, ``.python-version`` files, and the global default.
+
+pyenv isn't a tool for managing virtual environments, but there is a plugin
+`pyenv-virtualenv <https://github.com/yyuu/pyenv-virtualenv>`_ which automates
+the creation of different environments, and also makes it possible to use the
+existing pyenv tools to switch to different environments based on environment
+variables or ``.python-version`` files.
 
 Other Tools
 :::::::::::

--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -253,7 +253,7 @@ first, and uses the fake version, which in turn passes the command on to
 pyenv.  pyenv then works out which version of Python should be run based on
 environment variables, ``.python-version`` files, and the global default.
 
-pyenv isn't a tool for managing virtual environments, but there is a plugin
+pyenv isn't a tool for managing virtual environments, but there is the plugin
 `pyenv-virtualenv <https://github.com/yyuu/pyenv-virtualenv>`_ which automates
 the creation of different environments, and also makes it possible to use the
 existing pyenv tools to switch to different environments based on environment


### PR DESCRIPTION
#395 suggests adding a section on [pyenv](https://github.com/yyuu/pyenv), and is marked as "PR Would be Accepted".

I've added a section on pyenv under `Your Development Environment > Interpreter Tools`.  I've talked about how it lets different versions be installed side-by-side, how it allows for multiple interpreters, briefly mentioned how it works, and also suggested the use of [pyenv-virtualenv](https://github.com/yyuu/pyenv-virtualenv) which integrates virtualenvs into the pyenv workflow.

I haven't included demonstrations of how to use it, because none of the other sections seem to have that.