### PR TITLE
Change to link to point to "dev" version of documentation in Django docs

### DIFF
--- a/docs/scenarios/db.rst
+++ b/docs/scenarios/db.rst
@@ -31,7 +31,7 @@ The Django ORM is the interface used by `Django <http://www.djangoproject.com>`_
 to provide database access.
 
 It's based on the idea of
-`models <https://docs.djangoproject.com/en/1.3/#the-model-layer>`_,
+`models <https://docs.djangoproject.com/en/dev/#the-model-layer>`_,
 an abstraction that makes it easier to manipulate data in Python.
 
 The basics:


### PR DESCRIPTION
The link for "models" in http://docs.python-guide.org/en/latest/scenarios/db/#django-orm is pointing a page that no longer exists. This changes it to point to the 'dev' version of docs in the django project.