### PR TITLE
explicitely state EOL year for python 2

### DIFF
--- a/docs/starting/which-python.rst
+++ b/docs/starting/which-python.rst
@@ -15,7 +15,7 @@ The basic gist of the state of things is as follows:
 
 1. Python 2.7 has been the standard for a *long* time.
 2. Python 3 introduced major changes to the language, which many developers are unhappy with.
-3. Python 2.7 will receive necessary security updates for a few years.
+3. Python 2.7 will receive necessary security updates until 2020 [#pep373_eol].
 4. Python 3 is continually evolving, like Python 2 did in years past.
 
 So, you can now see why this is not such an easy decision.
@@ -151,3 +151,5 @@ PythonNet supports from Python 2.3 up to Python 2.7. [#pythonnet_ver]_
 .. [#iron_ver] http://ironpython.codeplex.com/releases/view/81726
 
 .. [#pythonnet_ver] http://pythonnet.github.io/readme.html
+
+.. [#pep373_eol] https://www.python.org/dev/peps/pep-0373/#id2


### PR DESCRIPTION
Plus link to relevant pep section in case of updates. 