### PR TITLE
 Add link to EOL date

### DIFF
--- a/docs/starting/which-python.rst
+++ b/docs/starting/which-python.rst
@@ -15,7 +15,7 @@ The basic gist of the state of things is as follows:
 
 1. Python 2.7 has been the standard for a *long* time.
 2. Python 3 introduced major changes to the language, which many developers are unhappy with.
-3. Python 2.7 will receive necessary security updates until 2020 [#pep373_eol].
+3. Python 2.7 `will receive necessary security updates until 2020 <https://www.python.org/dev/peps/pep-0373/>`_.
 4. Python 3 is continually evolving, like Python 2 did in years past.
 
 So, you can now see why this is not such an easy decision.

--- a/docs/starting/which-python.rst
+++ b/docs/starting/which-python.rst
@@ -15,7 +15,7 @@ The basic gist of the state of things is as follows:
 
 1. Python 2.7 has been the standard for a *long* time.
 2. Python 3 introduced major changes to the language, which many developers are unhappy with.
-3. Python 2.7 `will receive necessary security updates until 2020 <https://www.python.org/dev/peps/pep-0373/>`_.
+3. Python 2.7 will receive necessary security updates until 2020 [#pep373_eol]_.
 4. Python 3 is continually evolving, like Python 2 did in years past.
 
 So, you can now see why this is not such an easy decision.


### PR DESCRIPTION
Creates a link to the official page stating 2020 as EOL.

Fixes #588

(Sorry if this appears twice - my git-fu is weak.)