### PR TITLE
add note about XCode commandline tools in initial mac guide

### DIFF
--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -32,6 +32,10 @@ package.
     In combination, the software can cause issues that are difficult to
     diagnose.
 
+.. note::
+    If you perform a fresh install of XCode, you will also need to add the 
+    commandline tools by running `xcode-select --install` on the terminal.
+
 While OS X comes with a large number of UNIX utilities, those familiar with
 Linux systems will notice one key component missing: a decent package manager.
 `Homebrew <http://brew.sh>`_ fills this void.

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -34,7 +34,7 @@ package.
 
 .. note::
     If you perform a fresh install of XCode, you will also need to add the 
-    commandline tools by running `xcode-select --install` on the terminal.
+    commandline tools by running ``xcode-select --install`` on the terminal.
 
 While OS X comes with a large number of UNIX utilities, those familiar with
 Linux systems will notice one key component missing: a decent package manager.


### PR DESCRIPTION
Installing XCode isn't enough - minus the commandline tools, you'll get c compiler errors when you `brew install python`.