### PR TITLE
Update list of distros that come with 2.7

### DIFF
--- a/docs/starting/install/linux.rst
+++ b/docs/starting/install/linux.rst
@@ -3,9 +3,7 @@
 Installing Python on Linux
 ==========================
 
-The latest versions of Ubuntu and Fedora **come with Python 2.7 out of the box**.
-
-The latest versions of Redhat Enterprise (RHEL) and CentOS come with Python 2.6.
+The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu **come with Python 2.7 out of the box**.
 
 To see which version of Python you have installed, open a command prompt and run
 

--- a/docs/starting/install/linux.rst
+++ b/docs/starting/install/linux.rst
@@ -3,7 +3,8 @@
 Installing Python on Linux
 ==========================
 
-The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu **come with Python 2.7 out of the box**.
+The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu **
+come with Python 2.7 out of the box**.
 
 To see which version of Python you have installed, open a command prompt and run
 

--- a/docs/starting/install/linux.rst
+++ b/docs/starting/install/linux.rst
@@ -3,8 +3,8 @@
 Installing Python on Linux
 ==========================
 
-The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu **
-come with Python 2.7 out of the box**.
+The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu 
+**come with Python 2.7 out of the box**.
 
 To see which version of Python you have installed, open a command prompt and run
 


### PR DESCRIPTION
The latest versions of all of these distros come w/ 2.7 now.

(Reference for RHEL: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.0_Release_Notes/sect-Red_Hat_Enterprise_Linux-7.0_Release_Notes-Compiler_and_Tools-Programming_Languages.html#idp12251048 )