### PR TITLE
Fixed spacing between index and links in table.

### DIFF
--- a/docs/_themes/kr/static/flasky.css_t
+++ b/docs/_themes/kr/static/flasky.css_t
@@ -307,7 +307,7 @@ table.field-list td {
 }
 
 table.footnote td.label {
-    width: 0px;
+    width: 2em;
     padding: 0.3em 0 0.3em 0.5em;
 }
 


### PR DESCRIPTION
This should fix the issue regarding the spacing in the table under PythonNet.