### PR TITLE
env.rst: fix typo

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -241,7 +241,7 @@ pyenv
 of the Python interpreter to be installed at the same time.  This solves the
 problem of having different projects requiring different versions of Python.
 For example, it becomes very easy to install Python 2.7 for compatibility in
-an one project, whilst still using Python 3.4 as the default interpreter.
+one project, whilst still using Python 3.4 as the default interpreter.
 pyenv isn't just limited to the CPython versions - it will also install PyPy,
 anaconda, miniconda, stackless, jython, and ironpython interpreters.
 


### PR DESCRIPTION
“in an one project” didn’t make sense. It should either be “in any project” or “in one project”.