### PR TITLE
Link to internal Virtual Environments page from install pages

### DIFF
--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -1,3 +1,5 @@
+.. _virtualenvironments-ref:
+
 Virtual Environments
 ====================
 

--- a/docs/starting/install/linux.rst
+++ b/docs/starting/install/linux.rst
@@ -58,7 +58,7 @@ your global site-packages directory clean and manageable.
 For example, you can work on a project which requires Django 1.3 while also
 maintaining a project which requires Django 1.0.
 
-To start using and see more information: `Virtual Environments <http://github.com/kennethreitz/python-guide/blob/master/docs/dev/virtualenvs.rst>`_ docs. 
+To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs. 
 
 You can also use :ref:`virtualenvwrapper <virtualenvwrapper-ref>` to make it easier to
 manage your virtual environments.

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -92,7 +92,7 @@ your global site-packages directory clean and manageable.
 For example, you can work on a project which requires Django 1.3 while also
 maintaining a project which requires Django 1.0.
 
-To start using and see more information: `Virtual Environments <http://github.com/kennethreitz/python-guide/blob/master/docs/dev/virtualenvs.rst>`_ docs. 
+To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs. 
 
 
 --------------------------------

--- a/docs/starting/install/win.rst
+++ b/docs/starting/install/win.rst
@@ -77,7 +77,7 @@ your global site-packages directory clean and manageable.
 For example, you can work on a project which requires Django 1.3 while also
 maintaining a project which requires Django 1.0.
 
-To start using and see more information: `Virtual Environments <http://github.com/kennethreitz/python-guide/blob/master/docs/dev/virtualenvs.rst>`_ docs. 
+To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs. 
 
 
 --------------------------------


### PR DESCRIPTION
At the bottom of the installation guides for Windows, OS X, and Linux, link to the site's own version of the Virtual Environments page, instead directly linking to the version on GitHub. This is a fix for issue #656.