### PR TITLE
Removing outdated Gittip donation method

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -8,16 +8,6 @@
 
 <p><a href="http://tinyletter.com/kennethreitz">Subscribe to Newsletter</a></p>
 
-<h3>Donate</h3>
-<p>
-    If you enjoy this guide, consider supporting the author <a href="https://gratipay.com/~kennethreitz/">on Gratipay</a>:
-</p>
-<p>
-  <iframe style="border: 0; margin: 0; padding: 0;"
-      src="https://gratipay.com/~kennethreitz/widget.html"
-      width="60pt" height="20pt"></iframe>
-</p>
-
 <h3>Contributors</h3>
 <p>
   This guide is the result of the collaboration of

--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -10,11 +10,11 @@
 
 <h3>Donate</h3>
 <p>
-    If you enjoy this guide, consider supporting the author <a href="https://www.gittip.com/kennethreitz/">on Gittip</a>:
+    If you enjoy this guide, consider supporting the author <a href="https://gratipay.com/~kennethreitz/">on Gratipay</a>:
 </p>
 <p>
   <iframe style="border: 0; margin: 0; padding: 0;"
-      src="https://www.gittip.com/kennethreitz/widget.html"
+      src="https://gratipay.com/~kennethreitz/widget.html"
       width="60pt" height="20pt"></iframe>
 </p>
 

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -10,10 +10,10 @@
 
 <h3>Donate</h3>
 <p>
-    If you enjoy this guide, consider supporting the author <a href="https://www.gittip.com/kennethreitz/">on Gittip</a>:
+    If you enjoy this guide, consider supporting the author <a href="https://gratipay.com/~kennethreitz/">on Gratipay</a>:
 </p>
 <p>
   <iframe style="border: 0; margin: 0; padding: 0;"
-      src="https://www.gittip.com/kennethreitz/widget.html"
+      src="https://gratipay.com/~kennethreitz/widget.html"
       width="60pt" height="20pt"></iframe>
 </p>

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -7,13 +7,3 @@
 <p>Receive updates on new releases and upcoming projects.</p>
 
 <p><a href="http://tinyletter.com/kennethreitz">Subscribe to Newsletter</a></p>
-
-<h3>Donate</h3>
-<p>
-    If you enjoy this guide, consider supporting the author <a href="https://gratipay.com/~kennethreitz/">on Gratipay</a>:
-</p>
-<p>
-  <iframe style="border: 0; margin: 0; padding: 0;"
-      src="https://gratipay.com/~kennethreitz/widget.html"
-      width="60pt" height="20pt"></iframe>
-</p>


### PR DESCRIPTION
It doesn't really look like anyone is donating money via the Gratipay service linked in the sidebar, but the name of the service in the sidebar was outdated. I fixed this since it could give readers the impression that the whole guide is outdated.