### PR TITLE
A note for xrange() use in Python 3. Issue #665

### DIFF
--- a/docs/writing/style.rst
+++ b/docs/writing/style.rst
@@ -349,7 +349,7 @@ Instead, use a list comprehension:
 
 .. code-block:: python
 
-    four_lists = [[] for __ in xrange(4)]
+    four_lists = [[] for __ in range(4)]
 
 Create a string from a list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/writing/style.rst
+++ b/docs/writing/style.rst
@@ -349,7 +349,9 @@ Instead, use a list comprehension:
 
 .. code-block:: python
 
-    four_lists = [[] for __ in range(4)]
+    four_lists = [[] for __ in xrange(4)]
+    
+Note: Use range() instead of xrange() in Python 3
 
 Create a string from a list
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Deprecated xrange() in Python 3
Reverted back previous commit of changing xrange. Added a note instead. 