### PR TITLE
Fix varibable name in XML parsing scenario

### DIFF
--- a/docs/scenarios/xml.rst
+++ b/docs/scenarios/xml.rst
@@ -59,7 +59,7 @@ can be loaded into a Python dict like this:
     import xmltodict
 
     with open('path/to/file.xml') as fd:
-        obj = xmltodict.parse(fd.read())
+        doc = xmltodict.parse(fd.read())
 
 and then you can access elements, attributes and values like this:
 


### PR DESCRIPTION
In the xmltodict example, the xml is loaded in the variable obj but is later referenced as doc.
Fixed by renaming obj to doc