### PR TITLE
Clarify Gondors stance

### DIFF
--- a/docs/scenarios/web.rst
+++ b/docs/scenarios/web.rst
@@ -233,7 +233,8 @@ information.
 
 Gondor has a guide on deploying `Django projects <https://gondor.io/support/django/setup/>`_.
 
-Gondor is run by a small company, and does not have a large number of users.
+Gondor is run by a small company and focuses on helping businesses find success with
+Python and Django.
 
 Templating
 ::::::::::


### PR DESCRIPTION
I don't think we should compare Gondor and Heroku simply based on user base. While it's true Heroku is the largest PaaS and Gondor is run by a small company, I think we should be a bit more explicit about how Gondor tries to differentiate themselves. Per conservations with @paltman, Gondor seems to much more of a partnership with companies aiming to launch Django/Pinax applications than a simple hosting company.

Including @jtauber @brosner, in no way do I wish to speak for Gondor or Eldarion :)