### PR TITLE
Include Youtube video of reading code 

### DIFF
--- a/docs/writing/reading.rst
+++ b/docs/writing/reading.rst
@@ -8,6 +8,14 @@ one thing that Python programmers do is read code.
 One of the secrets of becoming a great Python programmer is to read,
 understand, and comprehend excellent code.
 
+.. raw:: html
+
+    <iframe width="560" 
+            height="315" 
+            src="https://www.youtube.com/embed/Jc8M9-LoEuo" 
+            frameborder="0" allowfullscreen></iframe>
+
+
 Excellent code typically follows the guidelines outlined in
 :ref:`code_style`, and does its best to express a clear and concise
 intent to the reader.
@@ -45,7 +53,6 @@ reading. Each one of these projects is a paragon of Python coding.
 - `Tablib <https://github.com/kennethreitz/tablib>`_
   Tablib is a format-agnostic tabular dataset library, written in Python.
 
-.. todo:: Embed and explain YouTube video showing python code reading: http://www.youtube.com/watch?v=Jc8M9-LoEuo This may require installing a Sphinx plugin. https://bitbucket.org/birkenfeld/sphinx-contrib/src/a09f29fc16970f34350ca36ac7f229e00b1b1674/youtube?at=default
 
 .. todo:: Include code examples of exemplary code from each of the projects listed. Explain why it is excellent code. Use complex examples.
 


### PR DESCRIPTION
Using `.. raw:: html` directive.

I experimented with the spinxcontrib.youtube plugin, but it is buggy. See [my youtube-sphinxcontrib branch](https://github.com/serra/python-guide/commit/530d4910432d9a039cd6702b14515be09613d867), so I opted for this raw html approach instead.

I have not tested targets other than `html` and `singlehtml`.