### PR TITLE
I fail to see how Mule would help in Continuous Integration scenarios

### DIFF
--- a/docs/scenarios/ci.rst
+++ b/docs/scenarios/ci.rst
@@ -31,17 +31,6 @@ Buildbot
 automate the compile/test cycle to validate code changes.
 
 
-Mule
------
-
-`Mule <http://www.mulesoft.org/documentation/display/current/Mule+Fundamentals>`_
-is a lightweight integration platform that enables you to connect anything,
-anywhere. You can use Mule to intelligently manage message routing, data
-mapping, orchestration, reliability, security and scalability between nodes.
-Plug other systems and applications into Mule and let it handle all the
-communication between systems, enabling you to track and monitor everything
-that happens.
-
 
 Tox
 ---


### PR DESCRIPTION
afaik Mule is an Enterprise Service Bus, which can be useful in enterprise application integration scenarios, but imo an ESB is not useful in the context of continuous integration of Python programs.

If it ended up here by accident, let's remove it. If not, please reveal its intended use in CI scenarios.