### PR TITLE
Removed references to Setuptools/easy_install in favor of pip.  

### DIFF
--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -11,13 +11,6 @@ dilemma, and keeps your global site-packages directory clean and manageable.
 For example, you can work on a project which requires Django 1.9 while also
 maintaining a project which requires Django 1.8.
 
-If you are using Python 3, make sure you run something like the following (or
-have it in your env variables in ``~/.bashrc``):
-
-.. code-block:: console
-
-    $ export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3
-
 virtualenv
 ----------
 
@@ -50,13 +43,18 @@ in the current directory instead.
 This creates a copy of Python in whichever directory you ran the command in,
 placing it in a folder named :file:`venv`.
 
-You can also use the Python interpreter of your choice.
+You can also use the Python interpreter of your choice (like
+:file:`/usr/local/bin/python3`).
 
 .. code-block:: console
 
    $ virtualenv -p /usr/local/bin/python3 venv
 
-This will use the Python interpreter in :file:`/usr/local/bin/python3`
+or change the interpreter globally with an env variable in ``~/.bashrc``:
+
+.. code-block:: console
+
+   $ export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3
 
 2. To begin using the virtual environment, it needs to be activated:
 

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -8,15 +8,22 @@ projects in separate places, by creating virtual Python environments for them.
 It solves the "Project X depends on version 1.x but, Project Y needs 4.x"
 dilemma, and keeps your global site-packages directory clean and manageable.
 
-For example, you can work on a project which requires Django 1.3 while also
-maintaining a project which requires Django 1.0.
+For example, you can work on a project which requires Django 1.9 while also
+maintaining a project which requires Django 1.8.
+
+If you are using Python 3, make sure you run something like the following (or
+have it in your env variables in `~/.bashrc`):
+
+.. code-block:: console
+
+    $ export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3
 
 virtualenv
 ----------
 
 `virtualenv <http://pypi.python.org/pypi/virtualenv>`_ is a tool to create
-isolated Python environments. virtualenv creates a folder which contains all the 
-necessary executables to use the packages that a Python project would need. 
+isolated Python environments. virtualenv creates a folder which contains all the
+necessary executables to use the packages that a Python project would need.
 
 Install virtualenv via pip:
 
@@ -43,13 +50,13 @@ in the current directory instead.
 This creates a copy of Python in whichever directory you ran the command in,
 placing it in a folder named :file:`venv`.
 
-You can also use a Python interpreter of your choice.
+You can also use the Python interpreter of your choice.
 
 .. code-block:: console
 
-   $ virtualenv -p /usr/bin/python2.7 venv
+   $ virtualenv -p /usr/local/bin/python3 venv
 
-This will use the Python interpreter in :file:`/usr/bin/python2.7`
+This will use the Python interpreter in :file:`/usr/local/bin/python3`
 
 2. To begin using the virtual environment, it needs to be activated:
 
@@ -57,9 +64,9 @@ This will use the Python interpreter in :file:`/usr/bin/python2.7`
 
    $ source venv/bin/activate
 
-The name of the current virtual environment will now appear on the left of 
-the prompt (e.g. ``(venv)Your-Computer:your_project UserName$)`` to let you know 
-that it's active. From now on, any package that you install using pip will be 
+The name of the current virtual environment will now appear on the left of
+the prompt (e.g. ``(venv)Your-Computer:your_project UserName$)`` to let you know
+that it's active. From now on, any package that you install using pip will be
 placed in the ``venv`` folder, isolated from the global Python installation.
 
 Install packages as usual, for example:
@@ -78,7 +85,7 @@ Install packages as usual, for example:
 This puts you back to the system's default Python interpreter with all its
 installed libraries.
 
-To delete a virtual environment, just delete its folder. (In this case, 
+To delete a virtual environment, just delete its folder. (In this case,
 it would be ``rm -rf venv``.)
 
 After a while, though, you might end up with a lot of virtual environments
@@ -102,8 +109,8 @@ the current state of the environment packages. To do this, run
 
 This will create a :file:`requirements.txt` file, which contains a simple
 list of all the packages in the current environment, and their respective
-versions. You can see the list of installed packages without the requirements 
-format using "pip list". Later it will be easier for a different developer 
+versions. You can see the list of installed packages without the requirements
+format using "pip list". Later it will be easier for a different developer
 (or you, if you need to re-create the environment) to install the same packages
 using the same versions:
 
@@ -143,7 +150,7 @@ To install (make sure **virtualenv** is already installed):
 .. code-block:: console
 
   $ pip install virtualenvwrapper-win
-  
+
 In Windows, the default path for WORKON_HOME is %USERPROFILE%\Envs
 
 Basic Usage

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -44,17 +44,17 @@ This creates a copy of Python in whichever directory you ran the command in,
 placing it in a folder named :file:`venv`.
 
 You can also use the Python interpreter of your choice (like
-:file:`/usr/local/bin/python3`).
+:file:`/usr/bin/python2.7`).
 
 .. code-block:: console
 
-   $ virtualenv -p /usr/local/bin/python3 venv
+   $ virtualenv -p /usr/bin/python2.7 venv
 
 or change the interpreter globally with an env variable in ``~/.bashrc``:
 
 .. code-block:: console
 
-   $ export VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python3
+   $ export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7
 
 2. To begin using the virtual environment, it needs to be activated:
 

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -12,7 +12,7 @@ For example, you can work on a project which requires Django 1.9 while also
 maintaining a project which requires Django 1.8.
 
 If you are using Python 3, make sure you run something like the following (or
-have it in your env variables in `~/.bashrc`):
+have it in your env variables in ``~/.bashrc``):
 
 .. code-block:: console
 

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -8,11 +8,7 @@ projects in separate places, by creating virtual Python environments for them.
 It solves the "Project X depends on version 1.x but, Project Y needs 4.x"
 dilemma, and keeps your global site-packages directory clean and manageable.
 
-<<<<<<< HEAD
-For example, you can work on a project which requires Django 1.9 while also
-=======
 For example, you can work on a project which requires Django 1.10 while also
->>>>>>> upstream/master
 maintaining a project which requires Django 1.8.
 
 virtualenv

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -33,7 +33,6 @@ minimal but unofficial
 package.
 
 .. note::
-<<<<<<< HEAD
     If you already have XCode installed, do not install OSX-GCC-Installer.
     In combination, the software can cause issues that are difficult to
     diagnose.
@@ -41,11 +40,7 @@ package.
 .. note::
     If you perform a fresh install of XCode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
-=======
-    If you already have Xcode installed or plan to use Homebrew, do not install
-    OSX-GCC-Installer. In combination, the software can cause issues that are
-    difficult to diagnose.
->>>>>>> upstream/master
+
 
 While OS X comes with a large number of UNIX utilities, those familiar with
 Linux systems will notice one key component missing: a decent package manager.

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -11,7 +11,7 @@ The latest version of Mac OS X, El Capitan, **comes with Python 2.7 out of the b
 You do not need to install or configure anything else to use Python. Having said
 that, I would strongly recommend that you install the tools and libraries
 described in the next section before you start building Python applications for
-real-world use. In particular, you should always install ``pip``, as it makes
+real-world use. In particular, you should always install Setuptools, as it makes
 it much easier for you to install and manage other third-party Python libraries.
 
 The version of Python that ships with OS X is great for learning but it's not
@@ -40,7 +40,7 @@ package.
     commandline tools by running ``xcode-select --install`` on the terminal.
 
 While OS X comes with a large number of UNIX utilities, those familiar with
-Linux systems will notice one key component missing: a package manager.
+Linux systems will notice one key component missing: a decent package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 
 To `install Homebrew <http://brew.sh/#install>`_, open :file:`Terminal` or
@@ -69,13 +69,18 @@ Now, we can install Python 2.7:
 This will take a minute or two.
 
 
-Pip
+Setuptools and Pip
 ----------------
 
-Homebrew installs ``pip`` for you.
+Homebrew installs Setuptools and ``pip`` for you.
+
+Setuptools enables you to download and install any compliant Python
+ -software over a network (usually the Internet) with a single command
+ -(``easy_install``). It also enables you to add this network installation
+ -capability to your own Python software with very little work.
 
 ``pip`` is a tool for easily installing and managing Python packages, that is
-recommended over the deprecated ``easy_install``. It is superior to
+recommended over ``easy_install``. It is superior to
 ``easy_install`` in `several ways
 <https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install>`_,
 and is actively maintained.

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -74,9 +74,6 @@ Now, we can install Python 2.7:
 
     $ brew install python
 
-<<<<<<< HEAD
-This will take a minute or two.
-=======
 or Python 3:
 
 .. code-block:: console
@@ -84,7 +81,6 @@ or Python 3:
     $ brew install python3
 
 This will take a minute or two. 
->>>>>>> upstream/master
 
 
 Setuptools and Pip
@@ -93,23 +89,13 @@ Setuptools and Pip
 Homebrew installs Setuptools and ``pip`` for you.
 
 Setuptools enables you to download and install any compliant Python
-<<<<<<< HEAD
- -software over a network (usually the Internet) with a single command
- -(``easy_install``). It also enables you to add this network installation
- -capability to your own Python software with very little work.
-
-``pip`` is a tool for easily installing and managing Python packages, that is
-recommended over ``easy_install``. It is superior to
-``easy_install`` in `several ways
-<https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install>`_,
-=======
 software over a network (usually the Internet) with a single command
 (``easy_install``). It also enables you to add this network installation
 capability to your own Python software with very little work.
 
 ``pip`` is a tool for easily installing and managing Python packages,
-that is recommended over ``easy_install``. It is superior to ``easy_install`` in `several ways <https://python-packaging-user-guide.readthedocs.io/pip_easy_install/#pip-vs-easy-install>`_,
->>>>>>> upstream/master
+that is recommended over ``easy_install``. It is superior to ``easy_install``
+in `several ways <https://python-packaging-user-guide.readthedocs.io/pip_easy_install/#pip-vs-easy-install>`_,
 and is actively maintained.
 
 
@@ -122,13 +108,7 @@ in separate places, by creating virtual Python environments for them. It solves 
 your global site-packages directory clean and manageable.
 
 For example, you can work on a project which requires Django 1.10 while also
-<<<<<<< HEAD
-maintaining a project which requires Django 1.7.
-=======
 maintaining a project which requires Django 1.8.
-
-To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs. 
->>>>>>> upstream/master
 
 To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs.
 

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -5,11 +5,11 @@ Installing Python on Mac OS X
 
 The latest version of Mac OS X, El Capitan, **comes with Python 2.7 out of the box**.
 
-You do not need to install or configure anything else to use Python. Having
-said that, I would strongly recommend that you install the tools and libraries
-described in the next section before you start building Python applications
-for real-world use. In particular, you should always install Setuptools, as it
-makes it much easier for you to use other third-party Python libraries.
+You do not need to install or configure anything else to use Python. Having said
+that, I would strongly recommend that you install the tools and libraries
+described in the next section before you start building Python applications for
+real-world use. In particular, you should always install ``pip``, as it makes
+it much easier for you to install and manage other third-party Python libraries.
 
 The version of Python that ships with OS X is great for learning but it's not
 good for development. The version shipped with OS X may be out of date from the
@@ -33,11 +33,11 @@ package.
     diagnose.
 
 .. note::
-    If you perform a fresh install of XCode, you will also need to add the 
+    If you perform a fresh install of XCode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
 
 While OS X comes with a large number of UNIX utilities, those familiar with
-Linux systems will notice one key component missing: a decent package manager.
+Linux systems will notice one key component missing: a package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 
 To `install Homebrew <http://brew.sh/#install>`_, open :file:`Terminal` or
@@ -63,37 +63,33 @@ Now, we can install Python 2.7:
 
     $ brew install python
 
-This will take a minute or two. 
+This will take a minute or two.
 
 
-Setuptools & Pip
+Pip
 ----------------
 
-Homebrew installs Setuptools and ``pip`` for you.
+Homebrew installs ``pip`` for you.
 
-Setuptools enables you to download and install any compliant Python
-software over a network (usually the Internet) with a single command
-(``easy_install``). It also enables you to add this network installation
-capability to your own Python software with very little work.
-
-``pip`` is a tool for easily installing and managing Python packages,
-that is recommended over ``easy_install``. It is superior to ``easy_install`` in `several ways <https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install>`_,
+``pip`` is a tool for easily installing and managing Python packages, that is
+recommended over the deprecated ``easy_install``. It is superior to
+``easy_install`` in `several ways
+<https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install>`_,
 and is actively maintained.
 
 
 Virtual Environments
 --------------------
 
-A Virtual Environment is a tool to keep the dependencies required by different projects 
-in separate places, by creating virtual Python environments for them. It solves the 
-"Project X depends on version 1.x but, Project Y needs 4.x" dilemma, and keeps 
+A Virtual Environment (commonly referred to as a 'virtualenv') is a tool to keep the dependencies required by different projects
+in separate places, by creating virtual Python environments for them. It solves the
+"Project X depends on version 1.x but, Project Y needs 4.x" dilemma, and keeps
 your global site-packages directory clean and manageable.
 
-For example, you can work on a project which requires Django 1.3 while also
-maintaining a project which requires Django 1.0.
+For example, you can work on a project which requires Django 1.10 while also
+maintaining a project which requires Django 1.7.
 
-To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs. 
-
+To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs.
 
 --------------------------------
 

--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -1,18 +1,12 @@
-.. _install-osx:
+.. _install3-osx:
 
-Installing Python on Mac OS X
-=============================
-
-.. note::
-    Check out our :ref:`guide for installing Python 3 on OS X<install3-osx>`.
+Installing Python 3 on Mac OS X
+================================
 
 The latest version of Mac OS X, El Capitan, **comes with Python 2.7 out of the box**.
 
-You do not need to install or configure anything else to use Python. Having said
-that, I would strongly recommend that you install the tools and libraries
-described in the next section before you start building Python applications for
-real-world use. In particular, you should always install ``pip``, as it makes
-it much easier for you to install and manage other third-party Python libraries.
+You do not need to install or configure anything else to use Python 2. These
+instructions document the installation of Python 3.
 
 The version of Python that ships with OS X is great for learning but it's not
 good for development. The version shipped with OS X may be out of date from the
@@ -60,11 +54,11 @@ line at the bottom of your :file:`~/.profile` file
 
     export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 
-Now, we can install Python 2.7:
+Now, we can install Python 3:
 
 .. code-block:: console
 
-    $ brew install python
+    $ brew install python3
 
 This will take a minute or two.
 
@@ -72,25 +66,47 @@ This will take a minute or two.
 Pip
 ----------------
 
-Homebrew installs ``pip`` for you.
+Homebrew installs ``pip3`` for you.
 
-``pip`` is a tool for easily installing and managing Python packages, that is
-recommended over the deprecated ``easy_install``. It is superior to
-``easy_install`` in `several ways
-<https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install>`_,
-and is actively maintained.
+``pip3`` is the alias for the Python 3 version of ``pip`` on systems with both
+the Homebrew'd Python 2 and 3 installed.
+
+Working with Python3
+--------------------
+
+At this point, you have the system Python 2.7 available, potentially the
+:ref:`Homebrew version of Python 2 <install-osx>` installed, and the Homebrew
+version of Python 3 as well.
+
+.. code-block:: console
+
+    $ python
+
+will launch the Python 2 interpreter.
+
+.. code-block:: console
+
+    $ python3
+
+will launch the Python 3 interpreter
+
+``pip3`` and ``pip`` will both be available.  If the Homebrew version of Python
+2 is not installed, they will be the same.  If the Homebrew version of Python 2
+is installed then ``pip`` will point to Python 2 and ``pip3`` will point to
+Python 3.
 
 
 Virtual Environments
 --------------------
 
-A Virtual Environment (commonly referred to as a 'virtualenv') is a tool to keep the dependencies required by different projects
-in separate places, by creating virtual Python environments for them. It solves the
-"Project X depends on version 1.x but, Project Y needs 4.x" dilemma, and keeps
-your global site-packages directory clean and manageable.
+A Virtual Environment (commonly referred to as a 'virtualenv') is a tool to keep
+the dependencies required by different projects in separate places, by creating
+virtual Python environments for them. It solves the "Project X depends on
+version 1.x but, Project Y needs 4.x" dilemma, and keeps your global
+site-packages directory clean and manageable.
 
 For example, you can work on a project which requires Django 1.10 while also
-maintaining a project which requires Django 1.7.
+maintaining a project which requires Django 1.8.
 
 To start using this and see more information: :ref:`Virtual Environments <virtualenvironments-ref>` docs.
 

--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -7,17 +7,16 @@ If so, you do not need to install or configure anything else to use Python.
 Having said that, I would strongly recommend that you install the tools and
 libraries described in the guides below before you start building Python
 applications for real-world use. In particular, you should always install
-Pip, and Virtualenv — they make it much easier for you to use
+Setuptools, Pip, and Virtualenv — they make it much easier for you to use
 other third-party Python libraries.
 
 Installation Guides
 -------------------
 
 These guides go over the proper installation of :ref:`Python <which-python>`
-for development purposes, as well as pip and virtualenv.
+for development purposes, as well as setuptools, pip and virtualenv.
 
 - :ref:`Python 3 on Mac OS X <install3-osx>`.
-
 - :ref:`Python 2 on Mac OS X <install-osx>`.
 - :ref:`Python 2 on Microsoft Windows <install-windows>`.
 - :ref:`Python 2 on Ubuntu Linux <install-linux>`.

--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -7,14 +7,14 @@ If so, you do not need to install or configure anything else to use Python.
 Having said that, I would strongly recommend that you install the tools and
 libraries described in the guides below before you start building Python
 applications for real-world use. In particular, you should always install
-Setuptools, Pip, and Virtualenv — they make it much easier for you to use
+Pip, and Virtualenv — they make it much easier for you to use
 other third-party Python libraries.
 
 Installation Guides
 -------------------
 
 These guides go over the proper installation of :ref:`Python 2.7 <which-python>`
-for development purposes, as well as setuptools, pip, and virtualenv setup.
+for development purposes, as well as pip and virtualenv.
 
 - :ref:`Mac OS X <install-osx>`.
 - :ref:`Microsoft Windows <install-windows>`.

--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -13,9 +13,11 @@ other third-party Python libraries.
 Installation Guides
 -------------------
 
-These guides go over the proper installation of :ref:`Python 2.7 <which-python>`
+These guides go over the proper installation of :ref:`Python <which-python>`
 for development purposes, as well as pip and virtualenv.
 
-- :ref:`Mac OS X <install-osx>`.
-- :ref:`Microsoft Windows <install-windows>`.
-- :ref:`Ubuntu Linux <install-linux>`.
+- :ref:`Python 3 on Mac OS X <install3-osx>`.
+
+- :ref:`Python 2 on Mac OS X <install-osx>`.
+- :ref:`Python 2 on Microsoft Windows <install-windows>`.
+- :ref:`Python 2 on Ubuntu Linux <install-linux>`.


### PR DESCRIPTION
A new Python user hardly needs to know that easy_install ever existed.  

Also addresses #676 for OS X.  Open to suggestions.
