### PR TITLE
Updates command for installing Homebrew

### DIFF
--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -45,7 +45,7 @@ your favorite OSX terminal emulator and run
 
 .. code-block:: console
 
-    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
 The script will explain what changes it will make and prompt you before the
 installation begins.


### PR DESCRIPTION
As can be seen on the [Homebrew website](http://brew.sh/), it seems that
Homebrew is now recommending that you install Homebrew by calling
`/usr/bin/ruby` instead of just `ruby`.