### PR TITLE
Changed summary line of docstring to follow PEP 0257

### DIFF
--- a/docs/writing/tests.rst
+++ b/docs/writing/tests.rst
@@ -116,7 +116,7 @@ A simple doctest in a function:
 .. code-block:: python
 
     def square(x):
-        """Square x.
+        """Return the square of x.
 
         >>> square(2)
         4

--- a/docs/writing/tests.rst
+++ b/docs/writing/tests.rst
@@ -116,7 +116,7 @@ A simple doctest in a function:
 .. code-block:: python
 
     def square(x):
-        """Squares x.
+        """Square x.
 
         >>> square(2)
         4


### PR DESCRIPTION
Quoting https://www.python.org/dev/peps/pep-0257/#one-line-docstrings

> "The docstring is a phrase ending in a period. It prescribes the function or method's effect as a command ("Do this", "Return that"), not as a description; e.g. don't write "Returns the pathname ..."."