### PR TITLE
pyca/cryptography no longer supports Python 3.2.

### DIFF
--- a/docs/scenarios/crypto.rst
+++ b/docs/scenarios/crypto.rst
@@ -6,7 +6,7 @@ Cryptography
 
 `Cryptography <https://cryptography.io/en/latest/>`_ is an actively developed
 library that provides cryptographic recipes and primitives. It supports 
-Python 2.6-2.7, Python 3.2+ and PyPy.
+Python 2.6-2.7, Python 3.3+ and PyPy.
 
 
 Cryptography is divided into two layers of recipes and hazardous materials


### PR DESCRIPTION
Python 3.2 support has been dropped from pyca/cryptography as of April 2015. https://github.com/pyca/cryptography/pull/1846