### PR TITLE
Fix incorrect dictConfig example

### DIFF
--- a/docs/writing/logging.rst
+++ b/docs/writing/logging.rst
@@ -163,10 +163,10 @@ the configuration dictionary.
                   'formatter': 'f',
                   'level': logging.DEBUG}
             },
-        loggers = {
-            'root': {'handlers': ['h'],
-                     'level': logging.DEBUG}
-            }
+        root = {
+            'handlers': ['h'],
+            'level': logging.DEBUG,
+            },
     )
 
     dictConfig(logging_config)


### PR DESCRIPTION
dictConfig expects a special `root` key *outside* of the `loggers` subdictionary in order to configure the root logger. I've tried the existing example code on python 2.7.5 and 3.5.1, and in neither case does the final log line produce any output (because the root logger remains set to `looging.WARN` by default). 

Changing the example to use the `root` key causes the log message to appear properly.

The `root` key is explained in PEP391: https://www.python.org/dev/peps/pep-0391/#dictionary-schema-detail