### PR TITLE
Don't treat targets as files

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -254,6 +254,8 @@ your project.
     test:
         py.test tests
 
+    .PHONY init test
+
 Other generic management scripts (e.g. ``manage.py``
 or ``fabfile.py``) belong at the root of the repository as well.
 


### PR DESCRIPTION
Currently, this sample Makefile has problems if there are any
files/directories named init or test in the same directory as the
makefile. This commit adds a phony to the sample Makefile so that these
targets are not treated as files.