### PR TITLE
Fix .PHONY target rule

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -254,7 +254,7 @@ your project.
     test:
         py.test tests
 
-    .PHONY init test
+    .PHONY: init test
 
 Other generic management scripts (e.g. ``manage.py``
 or ``fabfile.py``) belong at the root of the repository as well.


### PR DESCRIPTION
.PHONY should be followed by a colon in the Makefile