### PR TITLE
fix memoization typo, link to wikipedia's overview

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -602,7 +602,7 @@ clearer and thus preferred.
 This mechanism is useful for separating concerns and avoiding
 external un-related logic 'polluting' the core logic of the function
 or method. A good example of a piece of functionality that is better handled
-with decoration is memorization or caching: you want to store the results of an
+with decoration is `memoization <https://en.wikipedia.org/wiki/Memoization#Overview>` or caching: you want to store the results of an
 expensive function in a table and use them directly instead of recomputing
 them when they have already been computed. This is clearly not part
 of the function logic.


### PR DESCRIPTION
Memoization, while a 'big word' is a pretty simple concept, and everyone knows what caching is. While caching isn't strictly memoization, I've included a link to wikipedia's overview of it (which is very readable without understanding a lot of terminology)

I'm reasonably sure that this improves readability and content without distracting from the overall flow of the passage. I'd love comments.