### PR TITLE
include instructions to preview changes in CONTRIB

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,28 @@ see:
 
 http://docs.python-guide.org/en/latest/notes/contribute/
 
+How to test your changes
+------------------------
+
+The html version of this guide is built with [sphinx](http://www.sphinx-doc.org/en/stable/). You may test your revisions locally by having sphinx installed. You can do this easily with pip (as described in the link).
+
+``` bash
+pip install --user sphinx
+```
+
+Then navigate to the directory of the makefile and ```make build``` or ```make html```. Sphinx will then generate the html in a folder called _build/html
+
+After navigating to this folder, you can then use python's built in webserver to view your changes locally:
+
+``` bash
+python3 -m http.server
+```
+
+By default, http.server listens on every ip address bound on your host on port 8000. To bind to a specific one, say, localhost on port 8005:
+
+``` bash
+python3 -m http.server 8005 --bind 127.0.0.1
+```
 
 Style Guide
 -----------


### PR DESCRIPTION
These instructions detail how to build and preview changes the contributor has made as it would appear on the actual site.

This is very easy to setup provided you have python3 (http.server is called SimpleHTTPServer in python2). This seems to be a good quick way to test files visually (which would avoid screw ups like mine).
