### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -60,8 +60,8 @@
 <h3>Translations</h3>
 <ul>
   <li><a href="http://docs.python-guide.org/en/latest/">English</a></li>
-  <li><a href="http://python-guide-fr.readthedocs.io/fr/latest/">French</a></li>
-  <li><a href="http://pythonguidecn.readthedocs.org/zh/latest/">Chinese</a></li>
-  <li><a href="http://python-guide-ja.readthedocs.org/en/latest/">Japanese</a></li>
-  <li><a href="http://python-guide-kr.readthedocs.org/ko/latest/">Korean</a></li>
+  <li><a href="https://python-guide-fr.readthedocs.io/fr/latest/">French</a></li>
+  <li><a href="https://pythonguidecn.readthedocs.io/zh/latest/">Chinese</a></li>
+  <li><a href="https://python-guide-ja.readthedocs.io/en/latest/">Japanese</a></li>
+  <li><a href="https://python-guide-kr.readthedocs.io/ko/latest/">Korean</a></li>
 </ul>

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -42,8 +42,8 @@
 <h3>Translations</h3>
 <ul>
   <li><a href="http://docs.python-guide.org/en/latest/">English</a></li>
-  <li><a href="http://python-guide-fr.readthedocs.io/fr/latest/">French</a></li>
-  <li><a href="http://pythonguidecn.readthedocs.org/zh/latest/">Chinese</a></li>
-  <li><a href="http://python-guide-ja.readthedocs.org/en/latest/">Japanese</a></li>
-  <li><a href="http://python-guide-kr.readthedocs.org/ko/latest/">Korean</a></li>
+  <li><a href="https://python-guide-fr.readthedocs.io/fr/latest/">French</a></li>
+  <li><a href="https://pythonguidecn.readthedocs.io/zh/latest/">Chinese</a></li>
+  <li><a href="https://python-guide-ja.readthedocs.io/en/latest/">Japanese</a></li>
+  <li><a href="https://python-guide-kr.readthedocs.io/ko/latest/">Korean</a></li>
 </ul>

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -122,7 +122,7 @@ control by adding it to the ignore list.
 virtualenvwrapper
 -----------------
 
-`virtualenvwrapper <http://virtualenvwrapper.readthedocs.org/en/latest/index.html>`_
+`virtualenvwrapper <https://virtualenvwrapper.readthedocs.io/en/latest/index.html>`_
 provides a set of commands which makes working with virtual environments much
 more pleasant. It also places all your virtual environments in one place.
 
@@ -134,7 +134,7 @@ To install (make sure **virtualenv** is already installed):
   $ export WORKON_HOME=~/Envs
   $ source /usr/local/bin/virtualenvwrapper.sh
 
-(`Full virtualenvwrapper install instructions <http://virtualenvwrapper.readthedocs.org/en/latest/install.html>`_.)
+(`Full virtualenvwrapper install instructions <https://virtualenvwrapper.readthedocs.io/en/latest/install.html>`_.)
 
 For Windows, you can use the `virtualenvwrapper-win <https://github.com/davidmarble/virtualenvwrapper-win/>`_.
 
@@ -206,7 +206,7 @@ Other useful commands
 ``lssitepackages``
   Shows contents of :file:`site-packages` directory.
 
-`Full list of virtualenvwrapper commands <http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html>`_.
+`Full list of virtualenvwrapper commands <https://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html>`_.
 
 virtualenv-burrito
 ------------------

--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -38,7 +38,7 @@ without having to install Python locally.
 If you want a more traditional book, *Python For You and Me* is an excellent
 resource for learning all aspects of the language.
 
-    `Python for You and Me <http://pymbook.readthedocs.org/>`_
+    `Python for You and Me <https://pymbook.readthedocs.io/>`_
 
 Online Python Tutor
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/scenarios/ci.rst
+++ b/docs/scenarios/ci.rst
@@ -35,7 +35,7 @@ automate the compile/test cycle to validate code changes.
 Tox
 ---
 
-`tox <http://tox.readthedocs.org/en/latest/>`_ is an automation tool providing
+`tox <https://tox.readthedocs.io/en/latest/>`_ is an automation tool providing
 packaging, testing and deployment of Python software right from the console or
 CI server. It is a generic virtualenv management and test command line tool
 which provides the following features:

--- a/docs/scenarios/clibs.rst
+++ b/docs/scenarios/clibs.rst
@@ -4,7 +4,7 @@ Interfacing with C/C++ Libraries
 C Foreign Function Interface
 ----------------------------
 
-`CFFI <https://cffi.readthedocs.org/en/latest/>`_ provides a simple to use
+`CFFI <https://cffi.readthedocs.io/en/latest/>`_ provides a simple to use
 mechanism for interfacing with C from both CPython and PyPy. It supports two
 modes: an inline ABI compatibility mode (example provided below), which allows
 you to dynamically load and run functions from executable modules (essentially

--- a/docs/scenarios/db.rst
+++ b/docs/scenarios/db.rst
@@ -60,11 +60,11 @@ peewee
 `peewee <http://docs.peewee-orm.com/en/latest/>`_ is another ORM with a focus
 on being lightweight with support for Python 2.6+ and 3.2+ which supports
 SQLite, MySQL and Postgres by default. The
-`model layer <https://peewee.readthedocs.org/en/latest/peewee/quickstart.html#model-definition>`_
+`model layer <https://peewee.readthedocs.io/en/latest/peewee/quickstart.html#model-definition>`_
 is similar to that of the Django ORM and it has
-`SQL-like methods <https://peewee.readthedocs.org/en/latest/peewee/quickstart.html#retrieving-data>`_
+`SQL-like methods <https://peewee.readthedocs.io/en/latest/peewee/quickstart.html#retrieving-data>`_
 to query data. While SQLite, MySQL and Postgres are supported out-of-the-box,
-there is a `collection of add-ons <https://peewee.readthedocs.org/en/latest/peewee/playhouse.html#playhouse>`_
+there is a `collection of add-ons <https://peewee.readthedocs.io/en/latest/peewee/playhouse.html#playhouse>`_
 available.
 
 PonyORM

--- a/docs/scenarios/gui.rst
+++ b/docs/scenarios/gui.rst
@@ -28,7 +28,7 @@ applications be ported from PyGTK to PyGObject.
 PyGObject aka (PyGi)
 --------------------
 `PyGObject <https://wiki.gnome.org/Projects/PyGObject>`_ provides Python bindings, which gives access to the entire GNOME software platform.
-It is fully compatible with GTK+ 3. Here is a tutorial to get started with `Python GTK+ 3 Tutorial <http://python-gtk-3-tutorial.readthedocs.org/en/latest/>`_.
+It is fully compatible with GTK+ 3. Here is a tutorial to get started with `Python GTK+ 3 Tutorial <https://python-gtk-3-tutorial.readthedocs.io/en/latest/>`_.
 
 `API Reference <http://lazka.github.io/pgi-docs/>`_
 

--- a/docs/scenarios/imaging.rst
+++ b/docs/scenarios/imaging.rst
@@ -24,7 +24,7 @@ Installation
 
 Before installing Pillow, you'll have to install Pillow's prerequisites. Find
 the instructions for your platform in the
-`Pillow installation instructions <https://pillow.readthedocs.org/en/3.0.0/installation.html>`_.
+`Pillow installation instructions <https://pillow.readthedocs.io/en/3.0.0/installation.html>`_.
 
 After that, it's straightforward:
 
@@ -57,7 +57,7 @@ Example
     exif_data
 
 There are more examples of the Pillow library in the
-`Pillow tutorial <http://pillow.readthedocs.org/en/3.0.x/handbook/tutorial.html>`_.
+`Pillow tutorial <https://pillow.readthedocs.io/en/3.0.x/handbook/tutorial.html>`_.
 
 
 OpenSource Computer Vision
@@ -104,4 +104,4 @@ Example
 
 There are more Python-implemented examples of OpenCV in this `collection of
 tutorials
-<http://opencv-python-tutroals.readthedocs.org/en/latest/py_tutorials/py_tutorials.html>`_.
+<https://opencv-python-tutroals.readthedocs.io/en/latest/py_tutorials/py_tutorials.html>`_.

--- a/docs/scenarios/json.rst
+++ b/docs/scenarios/json.rst
@@ -47,7 +47,7 @@ simplejson
 
 The JSON library was added to Python in version 2.6.
 If you're using an earlier version of Python, the
-`simplejson <https://simplejson.readthedocs.org/en/latest/>`_ library is
+`simplejson <https://simplejson.readthedocs.io/en/latest/>`_ library is
 available via PyPI.
 
 simplejson mimics the json standard library. It is available so that developers

--- a/docs/scenarios/web.rst
+++ b/docs/scenarios/web.rst
@@ -154,7 +154,7 @@ Gunicorn is the recommended choice for new Python web applications today.
 Waitress
 --------
 
-`Waitress <http://waitress.readthedocs.org>`_ is a pure-python WSGI server
+`Waitress <https://waitress.readthedocs.io>`_ is a pure-python WSGI server
 that claims "very acceptable performance". Its documentation is not very
 detailed, but it does offer some nice functionality that Gunicorn doesn't have
 (e.g. HTTP request buffering).
@@ -166,18 +166,18 @@ Waitress is gaining popularity within the Python web development community.
 uWSGI
 -----
 
-`uWSGI <https://uwsgi-docs.readthedocs.org>`_ is a full stack for building
+`uWSGI <https://uwsgi-docs.readthedocs.io>`_ is a full stack for building
 hosting services.  In addition to process management, process monitoring,
 and other functionality, uWSGI acts as an application server for various
 programming languages and protocols - including Python and WSGI. uWSGI can
 either be run as a stand-alone web router, or be run behind a full web
 server (such as Nginx or Apache).  In the latter case, a web server can
 configure uWSGI and an application's operation over the
-`uwsgi protocol <https://uwsgi-docs.readthedocs.org/en/latest/Protocol.html>`_.
+`uwsgi protocol <https://uwsgi-docs.readthedocs.io/en/latest/Protocol.html>`_.
 uWSGI's web server support allows for dynamically configuring
 Python, passing environment variables and further tuning.  For full details,
 see `uWSGI magic
-variables <https://uwsgi-docs.readthedocs.org/en/latest/Vars.html>`_.
+variables <https://uwsgi-docs.readthedocs.io/en/latest/Vars.html>`_.
 
 I do not recommend using uWSGI unless you know why you need it.
 
@@ -393,10 +393,10 @@ Jinja2 is the recommended templating library for new Python web applications.
 Chameleon
 ---------
 
-`Chameleon <https://chameleon.readthedocs.org/>`_ Page Templates are an HTML/XML template
+`Chameleon <https://chameleon.readthedocs.io/>`_ Page Templates are an HTML/XML template
 engine implementation of the `Template Attribute Language (TAL) <http://en.wikipedia.org/wiki/Template_Attribute_Language>`_,
-`TAL Expression Syntax (TALES) <http://chameleon.readthedocs.org/en/latest/reference.html#expressions-tales>`_,
-and `Macro Expansion TAL (Metal) <http://chameleon.readthedocs.org/en/latest/reference.html#macros-metal>`_ syntaxes.
+`TAL Expression Syntax (TALES) <https://chameleon.readthedocs.io/en/latest/reference.html#expressions-tales>`_,
+and `Macro Expansion TAL (Metal) <https://chameleon.readthedocs.io/en/latest/reference.html#macros-metal>`_ syntaxes.
 
 Chameleon is available for Python 2.5 and up (including 3.x and pypy), and
 is commonly used by the `Pyramid Framework <http://trypyramid.com>`_.

--- a/docs/shipping/packaging.rst
+++ b/docs/shipping/packaging.rst
@@ -25,7 +25,7 @@ and being able and willing to use tools such as pip to install your code's
 other dependencies. This is fine when distributing to other developers, but
 makes this method unsuitable for distributing applications to end-users.
 
-The `Python Packaging Guide <https://python-packaging-user-guide.readthedocs.org/en/latest/>`_
+The `Python Packaging Guide <https://python-packaging-user-guide.readthedocs.io/>`_
 provides an extensive guide on creating and maintaining Python packages.
 
 Alternatives to Packaging
@@ -184,4 +184,4 @@ Useful Tools
 
 - `fpm <https://github.com/jordansissel/fpm>`_
 - `alien <http://joeyh.name/code/alien/>`_
-- `dh-virtualenv <http://dh-virtualenv.readthedocs.io/en/latest/info.html>`_ (for APT/DEB omnibus packaging)
+- `dh-virtualenv <https://dh-virtualenv.readthedocs.io/en/latest/info.html>`_ (for APT/DEB omnibus packaging)

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -77,7 +77,7 @@ software over a network (usually the Internet) with a single command
 capability to your own Python software with very little work.
 
 ``pip`` is a tool for easily installing and managing Python packages,
-that is recommended over ``easy_install``. It is superior to ``easy_install`` in `several ways <https://python-packaging-user-guide.readthedocs.org/en/latest/pip_easy_install/#pip-vs-easy-install>`_,
+that is recommended over ``easy_install``. It is superior to ``easy_install`` in `several ways <https://python-packaging-user-guide.readthedocs.io/pip_easy_install/#pip-vs-easy-install>`_,
 and is actively maintained.
 
 

--- a/docs/writing/tests.rst
+++ b/docs/writing/tests.rst
@@ -202,7 +202,7 @@ nose provides automatic test discovery to save you the hassle of manually
 creating test suites. It also provides numerous plugins for features such as
 xUnit-compatible test output, coverage reporting, and test selection.
 
-    `nose <http://readthedocs.org/docs/nose/en/latest/>`_
+    `nose <https://nose.readthedocs.io/en/latest/>`_
 
 
 tox


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.