### PR TITLE
Fixed example docstring

### DIFF
--- a/docs/writing/documentation.rst
+++ b/docs/writing/documentation.rst
@@ -104,7 +104,7 @@ In Python, *docstrings* describe modules, classes, and functions:
 .. code-block:: python
 
     def square_and_rooter(x):
-        """Returns the square root of self times self."""
+        """Return the square root of self times self."""
         ...
 
 In general, follow the comment section of :pep:`8#comments` (the "Python Style


### PR DESCRIPTION
PEP 257 says:

> The docstring is a phrase ending in a period. It prescribes the function or method's effect as a command ("Do this", "Return that"), not as a description; e.g. don't write "Returns the pathname ...".
