### PR TITLE
Removes Numba todo

### DIFF
--- a/docs/scenarios/speed.rst
+++ b/docs/scenarios/speed.rst
@@ -222,10 +222,6 @@ Pyrex
 Shedskin?
 ---------
 
-Numba
------
-.. todo:: Write about Numba and the autojit compiler for NumPy
-
 Concurrency
 :::::::::::
 


### PR DESCRIPTION
This todo can be removed, since information about Numba is included under [scenarios/scientific](http://docs.python-guide.org/en/latest/scenarios/scientific/#numba).
