### PR TITLE
Rename overly specific link

### DIFF
--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -18,4 +18,4 @@ for development purposes, as well as setuptools, pip, and virtualenv setup.
 
 - :ref:`Mac OS X <install-osx>`.
 - :ref:`Microsoft Windows <install-windows>`.
-- :ref:`Ubuntu Linux <install-linux>`.
+- :ref:`Linux <install-linux>`.


### PR DESCRIPTION
The linked page is general to Linux, and specifically mentions CentOS, Fedora, RHEL and Ubuntu. It does not contain any information that is specific to Ubuntu only.
