### PR TITLE
updated a broken link to Python Magic Methods

### DIFF
--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -210,7 +210,7 @@ and can make classes and objects behave in different and magical ways.
 
     `A Guide to Python's Magic Methods <http://www.rafekettler.com/magicmethods.html>`_
 Note: The Rafekettler.com is currently down, you can go to their Github version directly. Here you can find a PDF version:
-    `A Guide to Python's Magic Methods (repo on GitHub) <https://github.com/RafeKettler/magicmethods>`_
+    `A Guide to Python's Magic Methods (repo on GitHub) <https://github.com/RafeKettler/magicmethods/blob/master/magicmethods.pdf>`_
 
 
 For Engineers and Scientists

--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -209,6 +209,8 @@ in Python. Magic methods are surrounded by double underscores (i.e. __init__)
 and can make classes and objects behave in different and magical ways.
 
     `A Guide to Python's Magic Methods <http://www.rafekettler.com/magicmethods.html>`_
+Note: The Rafekettler.com is currently down, you can go to their Github version directly. Here you can find a PDF version:
+    `A Guide to Python's Magic Methods (repo on GitHub) <https://github.com/RafeKettler/magicmethods>`_
 
 
 For Engineers and Scientists

--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -209,7 +209,7 @@ in Python. Magic methods are surrounded by double underscores (i.e. __init__)
 and can make classes and objects behave in different and magical ways.
 
     `A Guide to Python's Magic Methods <http://www.rafekettler.com/magicmethods.html>`_
-Note: The Rafekettler.com is currently down, you can go to their Github version directly. Here you can find a PDF version:
+.. note:: The Rafekettler.com is currently down, you can go to their Github version directly. Here you can find a PDF version:
     `A Guide to Python's Magic Methods (repo on GitHub) <https://github.com/RafeKettler/magicmethods/blob/master/magicmethods.pdf>`_
 
 


### PR DESCRIPTION
The website rafekettler.com is down.
Reference: https://github.com/RafeKettler/magicmethods/issues/55