### PR TITLE
Click is stable - not upcoming

### DIFF
--- a/docs/scenarios/cli.rst
+++ b/docs/scenarios/cli.rst
@@ -30,7 +30,7 @@ column printer, iterator based progress bars and implicit argument handling.
 Click
 -----
 
-`click <http://click.pocoo.org/>`_ is an upcoming Python package for creating
+`click <http://click.pocoo.org/>`_ is a Python package for creating
 command-line interfaces in a composable way with as little code as
 possible. This “Command-line Interface Creation Kit” is highly
 configurable but comes with good defaults out of the box.


### PR DESCRIPTION
The Python CLI library Click is listed as "upcoming" when it is in fact stable. I think this scares some people away who might be well served by using it.

<img width="934" alt="screen shot 2016-12-11 at 8 32 21 pm" src="https://cloud.githubusercontent.com/assets/185043/21088146/7f287824-bfe1-11e6-9976-c9790d66ed30.png">
http://click.pocoo.org/6/