### PR TITLE
Update psutil project page to not use Google Code

### DIFF
--- a/docs/scenarios/admin.rst
+++ b/docs/scenarios/admin.rst
@@ -131,7 +131,7 @@ State files can be written using YAML, the Jinja2 template system or pure Python
 Psutil
 ------
 
-`Psutil <https://code.google.com/p/psutil/>`_ is an interface to different
+`Psutil <https://github.com/giampaolo/psutil/>`_ is an interface to different
 system information (e.g. CPU, memory, disks, network, users and processes).
 
 Here is an example to be aware of some server overload. If any of the


### PR DESCRIPTION
Since Google Code is defunct, the new homepage for `psutil` is on GitHub.  I've updated the link, nothing more.