### PR TITLE
Remove reference to Learning Python the Hardway.

### DIFF
--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -72,15 +72,6 @@ as programs that can break them.
     `Hacking Secret Ciphers with Python <http://inventwithpython.com/hacking/>`_
 
 
-Learn Python the Hard Way
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This is an excellent beginner programmer's guide to Python. It covers "hello
-world" from the console to the web.
-
-    `Learn Python the Hard Way <http://learnpythonthehardway.org/book/>`_
-
-
 Crash into Python
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The author only promotes python 2 and actively advocates against python 3, it isn't a good resource for new developers who should be learning how to use the currently recommended version of python.

see: https://learnpythonthehardway.org/book/nopython3.html