### PR TITLE
Broken link: W3 Schools XPath Tutorial

### DIFF
--- a/docs/scenarios/scrape.rst
+++ b/docs/scenarios/scrape.rst
@@ -49,7 +49,7 @@ will focus on the former.
 
 XPath is a way of locating information in structured documents such as
 HTML or XML documents. A good introduction to XPath is on
-`W3Schools <http://www.w3schools.com/xsl/xpath_intro.asp>`_ .
+`W3Schools <http://www.w3schools.com/xml/xpath_intro.asp>`_ .
 
 There are also various tools for obtaining the XPath of elements such as
 FireBug for Firefox or the Chrome Inspector. If you're using Chrome, you


### PR DESCRIPTION
The link to the W3 schools XPath tutorial in the the [HTML Scraping](http://docs.python-guide.org/en/latest/scenarios/scrape/) was broken. The link, <http://www.w3schools.com/xsl/xpath_intro.asp>, gave a 404, and was changed to <http://www.w3schools.com/xml/xpath_intro.asp>.