### PR TITLE
Update virtualenvs.rst

### DIFF
--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -32,23 +32,23 @@ Basic Usage
 .. code-block:: console
 
    $ cd my_project_folder
-   $ virtualenv venv
+   $ virtualenv my_project
 
-``virtualenv venv`` will create a folder in the current directory which will
+``virtualenv my_project`` will create a folder in the current directory which will
 contain the Python executable files, and a copy of the ``pip`` library which you
 can use to install other packages. The name of the virtual environment (in this
-case, it was ``venv``) can be anything; omitting the name will place the files
+case, it was ``my_project``) can be anything; omitting the name will place the files
 in the current directory instead.
 
 This creates a copy of Python in whichever directory you ran the command in,
-placing it in a folder named :file:`venv`.
+placing it in a folder named :file:`my_project`.
 
 You can also use the Python interpreter of your choice (like
 ``python2.7``).
 
 .. code-block:: console
 
-   $ virtualenv -p /usr/bin/python2.7 venv
+   $ virtualenv -p /usr/bin/python2.7 my_project
 
 or change the interpreter globally with an env variable in ``~/.bashrc``:
 
@@ -60,12 +60,12 @@ or change the interpreter globally with an env variable in ``~/.bashrc``:
 
 .. code-block:: console
 
-   $ source venv/bin/activate
+   $ source my_project/bin/activate
 
 The name of the current virtual environment will now appear on the left of
-the prompt (e.g. ``(venv)Your-Computer:your_project UserName$)`` to let you know
+the prompt (e.g. ``(my_project)Your-Computer:your_project UserName$)`` to let you know
 that it's active. From now on, any package that you install using pip will be
-placed in the ``venv`` folder, isolated from the global Python installation.
+placed in the ``my_project`` folder, isolated from the global Python installation.
 
 Install packages as usual, for example:
 
@@ -84,7 +84,7 @@ This puts you back to the system's default Python interpreter with all its
 installed libraries.
 
 To delete a virtual environment, just delete its folder. (In this case,
-it would be ``rm -rf venv``.)
+it would be ``rm -rf my_project``.)
 
 After a while, though, you might end up with a lot of virtual environments
 littered across your system, and its possible you'll forget their names or
@@ -158,15 +158,15 @@ Basic Usage
 
 .. code-block:: console
 
-   $ mkvirtualenv venv
+   $ mkvirtualenv my_project
 
-This creates the :file:`venv` folder inside :file:`~/Envs`.
+This creates the :file:`my_project` folder inside :file:`~/Envs`.
 
 2. Work on a virtual environment:
 
 .. code-block:: console
 
-   $ workon venv
+   $ workon my_project
 
 Alternatively, you can make a project, which creates the virtual environment,
 and also a project directory inside ``$PROJECT_HOME``, which is ``cd`` -ed into


### PR DESCRIPTION
Renames the virtual environment name from venv to my_project so that the reader is clear that they should not name their environment venv which could lead to confusion later (venv appearing on the left of the prompt)

Closes #795 