### PR TITLE
tests: use __file__ for package import

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -211,7 +211,7 @@ file:
 
     import os
     import sys
-    sys.path.insert(0, os.path.abspath('..'))
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
     import sample
 


### PR DESCRIPTION
To import the package in `tests/context.py` one should use:

```python
sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
```

rather than:

```python
sys.path.insert(0, os.path.abspath('..'))
```

This was already changed in [kennethreitz/samplemod](https://github.com/kennethreitz/samplemod/blob/master/tests/context.py), but not in the guide itself.

Explanation:

According to the [docs](https://docs.python.org/3.6/library/os.path.html) `os.path.abspath(path)` is equivalent to: `normpath(join(os.getcwd(), path))`.
    
`os.getcwd()` returns the path from where the Python interpreter was called, not the location of the executed file:

```bash
> tree dir1
dir1
└── dir2
    └── dir3
        └── rel_path.py
> cat dir1/rel_path.py
import os.path
print(os.path.abspath('..'))
print(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
> cd dir1/dir2/dir3
> python rel_path.py 
/home/user/dir1/dir2
/home/user/dir1/dir2
> cd ..
> python dir3/rel_path.py 
/home/user/dir1
/home/user/dir1/dir2
```