### PR TITLE
Remove junk in Jinja code block

### DIFF
--- a/docs/scenarios/web.rst
+++ b/docs/scenarios/web.rst
@@ -366,7 +366,7 @@ into the corresponding block in the :file:`base.html` page.
 
 .. code-block:: html
 
-    <!{% extends "base.html" %}
+    {% extends "base.html" %}
     {% block content %}
         <p class="important">
         <div id="content">


### PR DESCRIPTION
The "<!" before template extension statement is unnecessary and also breaks code highlighting.