### PR TITLE
Adding a reminder for preventing a misuse of the example in "common g…

### DIFF
--- a/docs/writing/gotchas.rst
+++ b/docs/writing/gotchas.rst
@@ -76,6 +76,7 @@ signal that no argument was provided (:py:data:`None` is often a good choice).
         to.append(element)
         return to
 
+Do not forget, you are passing a *list* object as the second argument.
 
 When the Gotcha Isn't a Gotcha
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Including reminder to prevent misuse of the example at [Common Gotchas](http://python-guide-pt-br.readthedocs.io/en/latest/writing/gotchas/): Mutable Default Arguments. In response to issue [#813](https://github.com/kennethreitz/python-guide/issues/813)