### PR TITLE
`pep8` is nowadays called `pycodestyle`

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -35,11 +35,11 @@ source files.
 There is also a handy syntax plugin called syntax_ featuring some improvements
 over the syntax file included in Vim 6.1.
 
-These plugins supply you with a basic environment for developing in Python.
-To get the most out of Vim, you should continually check your code for syntax
-errors and PEP8 compliance. Luckily PEP8_ and Pyflakes_ will do this for you.
-If your Vim is compiled with ``+python`` you can also utilize some very
-handy plugins to do these checks from within the editor.
+These plugins supply you with a basic environment for developing in Python. To
+get the most out of Vim, you should continually check your code for syntax
+errors and PEP8 compliance. Luckily pycodestyle_ and Pyflakes_ will do this
+for you. If your Vim is compiled with ``+python`` you can also utilize some
+very handy plugins to do these checks from within the editor.
 
 For PEP8 checking and pyflakes, you can install vim-flake8_. Now you can map the
 function ``Flake8`` to any hotkey or action you want in Vim. The plugin will
@@ -68,12 +68,12 @@ Python-mode
 Python-mode_ is a complex solution for working with Python code in Vim.
 It has:
 
-- Asynchronous Python code checking (``pylint``, ``pyflakes``, ``pep8``, ``mccabe``) in any combination
+- Asynchronous Python code checking (``pylint``, ``pyflakes``, ``pycodestyle``, ``mccabe``) in any combination
 - Code refactoring and autocompletion with Rope
 - Fast Python folding
 - Virtualenv support
 - Search through Python documentation and run Python code
-- Auto PEP8_ error fixes
+- Auto pycodestyle_ error fixes
 
 And more.
 
@@ -86,7 +86,7 @@ using ``<Tab>`` key or any other customized keys.
 .. _indent: http://www.vim.org/scripts/script.php?script_id=974
 .. _syntax: http://www.vim.org/scripts/script.php?script_id=790
 .. _Pyflakes: http://pypi.python.org/pypi/pyflakes/
-.. _PEP8: http://pypi.python.org/pypi/pep8/
+.. _pycodestyle: https://pypi.python.org/pypi/pycodestyle/
 .. _syntastic: https://github.com/scrooloose/syntastic
 .. _Python-mode: https://github.com/klen/python-mode
 .. _SuperTab: http://www.vim.org/scripts/script.php?script_id=1643

--- a/docs/writing/style.rst
+++ b/docs/writing/style.rst
@@ -459,23 +459,23 @@ best to adhere to the guidelines laid out within this document. Some project
 may sway from it from time to time, while others may
 `amend its recommendations <http://docs.python-requests.org/en/master/dev/contributing/#kenneth-reitz-s-code-style>`_.
 
-That being said, conforming your Python code to PEP 8 is generally a good
-idea and helps make code more consistent when working on projects with other
-developers. There is a command-line program, `pep8 <https://github.com/jcrocholl/pep8>`_,
-that can check your code for conformance. Install it by running the following
-command in your terminal:
+That being said, conforming your Python code to PEP 8 is generally a good idea
+and helps make code more consistent when working on projects with other
+developers. There is a command-line program, `pycodestyle <https://github.com/PyCQA/pycodestyle>`_
+(previously known as ``pep8``), that can check your code for conformance.
+Install it by running the following command in your terminal:
 
 
 .. code-block:: console
 
-    $ pip install pep8
+    $ pip install pycodestyle
 
 
 Then run it on a file or series of files to get a report of any violations.
 
 .. code-block:: console
 
-    $ pep8 optparse.py
+    $ pycodestyle optparse.py
     optparse.py:69:11: E401 multiple imports on one line
     optparse.py:77:1: E302 expected 2 blank lines, found 1
     optparse.py:88:5: E301 expected 1 blank line, found 0


### PR DESCRIPTION
See https://github.com/PyCQA/pycodestyle/issues/466. Pointing towards the `pep8` tool risks leading users to outdated versions of the tool (the last `pep8` version is 1.7.0 from January 2016; the currently latest `pycodestyle` version is 2.3.0).