### PR TITLE
Update the Linux installation instructions to reflect Fedora

### DIFF
--- a/docs/starting/install/linux.rst
+++ b/docs/starting/install/linux.rst
@@ -3,23 +3,22 @@
 Installing Python 2 on Linux
 ============================
 
-The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu
+The latest versions of CentOS, Red Hat Enterprise Linux (RHEL) and Ubuntu
 **come with Python 2.7 out of the box**.
 
 To see which version of Python you have installed, open a command prompt and run
 
 .. code-block:: console
 
-    $ python --version
+    $ python2 --version
 
-Some older versions of RHEL and CentOS come with Python 2.4 which is
-unacceptable for modern Python development. Fortunately, there are
-`Extra Packages for Enterprise Linux`_ which include high
-quality additional packages based on their Fedora counterparts. This
-repository contains a Python 2.6 package specifically designed to install
-side-by-side with the system's Python 2.4 installation.
+However, with the growing popularity of Python 3, some distributions, such as
+Fedora, don't come with Python 2 pre-installed. You can install the ``python2``
+package with your distribution package manager:
 
-.. _Extra Packages for Enterprise Linux: http://fedoraproject.org/wiki/EPEL
+.. code-block:: console
+
+    $ sudo dnf install python2
 
 You do not need to install or configure anything else to use Python. Having
 said that, I would strongly recommend that you install the tools and libraries

--- a/docs/starting/install3/linux.rst
+++ b/docs/starting/install3/linux.rst
@@ -22,6 +22,23 @@ If you're using another version of Ubuntu (e.g. the latest LTS release), we reco
     $ sudo apt-get update
     $ sudo apt-get install python3.6
 
+If you are using other Linux distribution, chances are you already have Python 3
+pre-installed as well. If not, use your distribution's package manager.
+For example on Fedora, you would use `dnf`:
+
+.. code-block:: console
+
+    $ sudo dnf install python3
+
+Note that if the version of the ``python3`` package is not recent enough
+for you, there may be ways of installing more recent versions as well,
+depending on you distribution. For example installing the ``python36`` package
+on Fedora 25 to get Python 3.6. If you are a Fedora user, you might want
+to read about `multiple Python versions available in Fedora`_.
+
+.. _multiple Python versions available in Fedora: https://developer.fedoraproject.org/tech/languages/python/multiple-pythons.html
+
+
 Working with Python 3
 ---------------------
 
@@ -58,6 +75,17 @@ To see if pip is installed, open a command prompt and run
     $ command -v pip
 
 To install pip, `follow the official pip installation guide <https://pip.pypa.io/en/latest/installing/>`_ - this will automatically install the latest version of setuptools.
+
+Note that on some Linux distributions including Ubuntu and Fedora the ``pip``
+command is meant for Python 2, while the ``pip3`` command is meant for Python 3.
+
+.. code-block:: console
+
+    $ command -v pip3
+
+However, when using virtual environments (described bellow), you don't need to
+care about that.
+
 
 Virtual Environments
 --------------------

--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -24,4 +24,4 @@ for development purposes, as well as setuptools, pip and virtualenv.
 
 - :ref:`Python 2 on MacOS <install-osx>`.
 - :ref:`Python 2 on Microsoft Windows <install-windows>`.
-- :ref:`Python 2 on Ubuntu Linux <install-linux>`.
+- :ref:`Python 2 on Linux <install-linux>`.


### PR DESCRIPTION
* Fedora does not come with Python 2 pre-installed since Fedora 23
 * RHEL with Python 2.4 is no longer supported (section removed)
 * Added Fedora installation instructions for Python 3.6 as well
 * Be carefull about /usr/bin/pip