### PR TITLE
fixing link to manual of PyInstaller.

### DIFF
--- a/docs/shipping/freezing.rst
+++ b/docs/shipping/freezing.rst
@@ -147,7 +147,7 @@ PyInstaller
 Prerequisite is to have installed :ref:`Python, Setuptools and pywin32 dependency on Windows <install-windows>`.
 
 - `Most basic tutorial <http://bojan-komazec.blogspot.com/2011/08/how-to-create-windows-executable-from.html>`_
-- `Manual <http://www.pyinstaller.org/export/d3398dd79b68901ae1edd761f3fe0f4ff19cfb1a/project/doc/Manual.html?format=raw>`_
+- `Manual <https://pyinstaller.readthedocs.io/en/stable/>`_
 
 
 OS X


### PR DESCRIPTION
The link to the PyInstaller was broken. I added the current link to the stable documentation.