### PR TITLE
 Changes in how homebrew installs Python on Mac OSX

### DIFF
--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -77,6 +77,15 @@ or Python 3:
 
 This will take a minute or two.
 
+Homebrew names the executable ``python2`` so that you can still run the system Python via the executable ``python``.
+
+
+.. code-block:: console
+
+    $ python -V   # system Python interpreter
+    $ python2 -V  # Homebrew installed Python 2 interpreter
+    $ python3 -V  # Homebrew installed Python 3 interpreter (if installed)
+
 
 Setuptools & Pip
 ----------------
@@ -92,6 +101,12 @@ capability to your own Python software with very little work.
 that is recommended over ``easy_install``. It is superior to ``easy_install``
 in `several ways <https://python-packaging-user-guide.readthedocs.io/pip_easy_install/#pip-vs-easy-install>`_,
 and is actively maintained.
+
+.. code-block:: console
+
+    $ pip2 -V  # pip pointing to the Homebrew installed Python 2 interpreter
+    $ pip3 -V  # pip pointing to the Homebrew installed Python 3 interpreter (if installed)
+
 
 
 Virtual Environments


### PR DESCRIPTION
Homebrew no longer sets pip.

See 5 executable names in https://docs.brew.sh/Homebrew-and-Python.html

    python points to the macOS system Python (with no manual PATH modification)
    python2 points to Homebrew’s Python 2.7.x (if installed)
    python3 points to Homebrew’s Python 3.x (if installed)
    pip2 points to Homebrew’s Python 2.7.x’s pip (if installed)
    pip3 points to Homebrew’s Python 3.x’s pip (if installed)