### PR TITLE
deadsnakes repository change

### DIFF
--- a/docs/starting/install3/linux.rst
+++ b/docs/starting/install3/linux.rst
@@ -18,9 +18,10 @@ If you are using Ubuntu 16.10 or newer, then you can easily install Python 3.6 w
     $ sudo apt-get update
     $ sudo apt-get install python3.6
 
-If you're using another version of Ubuntu (e.g. the latest LTS release), we recommend using the `deadsnakes PPA <https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes>`_ to install Python 3.6::
+If you're using another version of Ubuntu (e.g. the latest LTS release), we recommend using the `deadsnakes PPA <https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa>`_ to install Python 3.6::
 
-    $ sudo add-apt-repository ppa:fkrull/deadsnakes
+    $ sudo apt-get install software-properties-common
+    $ sudo add-apt-repository ppa:deadsnakes/ppa
     $ sudo apt-get update
     $ sudo apt-get install python3.6
 


### PR DESCRIPTION
When following the current instructions on ubuntu 16.04 LTS I got the following feedback:

```
~$ sudo add-apt-repository ppa:fkrull/deadsnakes
 Please use the new repository at

https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa

instead!
 More info: https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes
Press [ENTER] to continue or ctrl-c to cancel adding it
```
This PR updates the repo location.