### PR TITLE
Fix VS Code extension link

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -155,7 +155,7 @@ Edition (Apache 2.0 License) with fewer features.
 Python (on Visual Studio Code)
 ------------------------------
 
-`Python for Visual Studio <https://marketplace.visualstudio.com/items?itemName=donjayamanne.python>`_ is an extension for the `Visual Studio Code IDE <https://code.visualstudio.com>`_.
+`Python for Visual Studio <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ is an extension for the `Visual Studio Code IDE <https://code.visualstudio.com>`_.
 This is a free, light weight, open source IDE, with support for Mac, Windows, and Linux.
 Built using open source technologies such as Node.js and Python, with compelling features such as Intellisense (autocompletion), local and remote debugging, linting, and the like.
 


### PR DESCRIPTION
Addresses #869 - Microsoft now maintains the Python extension for VS Code, so the extension page's URL changed.