### PR TITLE
(osx) how to make `python` reference `python3`

### DIFF
--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -102,6 +102,22 @@ will launch the homebrew-installed Python 3 interpreter.
 If the Homebrew version of Python 2 is installed then ``pip2`` will point to Python 2.
 If the Homebrew version of Python 3 is installed then ``pip3`` will point to Python 3.
 
+The rest of the guide will assume that ``python`` references Python 3. You can simply choose to always invoke ``python3`` instead, and much is backwards compatible. However, performing the following steps will set Python 3 as the default interpreter for ``python`` in a shell.
+
+.. code-block:: console
+
+    # Do I have a Python 2 problem?
+    $ python --version
+    Python 2.7.10 # Referencing OSX system install
+    $ which python
+    /usr/bin/python # Yup, homebrew's would be in /usr/local/bin
+    
+    # Symlink /usr/local/bin/python to python3
+    $ ln -s /usr/local/bin/python3 /usr/local/bin/python
+    
+    $ python --version
+    Python 3.6.4 # Success! 
+    # If you still see 2.7 ensure in PATH /usr/local/bin/ takes pecedence over /usr/bin/
 
 Pipenv & Virtual Environments
 -----------------------------


### PR DESCRIPTION
I noticed that the next page, [Pipenv & Virtual Environments](http://docs.python-guide.org/en/latest/dev/virtualenvs/), re-enforces that `python` will be assumed to invoke the Python 3 interpreter and is Highly Preferred. The last mention on [Installing Python 3 for OSX](http://docs.python-guide.org/en/latest/starting/install3/osx/#working-with-python-3) leaves `python` referencing the OSX System Python interpreter (2.7.10 for high Sierra). 

I honestly do not know if this is the "correct" way to configure this default. It looks like brew is cautious about symlinking over the native Python 2.7.10 (High Sierra) and they might have good reason. 

All of my projects are Python 3 now, so i'm ready to "make it ~facebook~ PATH official with Python 3" - as I think the documentation makes abundantly clear is a goal to to strive for. 😂 

Regardless of how it's done - or if it's a bad idea and just saying sorry your SOL but use `python3`. This would at least remove a the discontinuity between pages and maybe help some people _not_ go through with the native interpreter, the worst of all options on OSX.