### PR TITLE
Fix link to the tests section

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -174,7 +174,7 @@ Test Suite
 ::::::::::
 
 
-*For advice on writing your tests, see :doc:`writing/tests`.*
+*For advice on writing your tests, see* :doc:`/writing/tests`.
 
 .. csv-table::
    :widths: 20, 40


### PR DESCRIPTION
Right now that link to the tests section doesn't get rendered as an HTML link, but instead the rst markup shows in the rendered HTML, like this:

![screen shot 2018-02-19 at 09 45 11](https://user-images.githubusercontent.com/3286144/36368921-b26f9fc2-1559-11e8-94e9-36908bec6daa.png)
