### PR TITLE
 Homebrew has changed how Python is installed 

### DIFF
--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -69,13 +69,13 @@ Now, we can install Python 2.7:
 
 .. code-block:: console
 
-    $ brew install python
+    $ brew install python@2
 
 or Python 3:
 
 .. code-block:: console
 
-    $ brew install python3
+    $ brew install python
 
 This will take a minute or two.
 
@@ -84,7 +84,7 @@ Homebrew names the executable ``python2`` so that you can still run the system P
 
 .. code-block:: console
 
-    $ python -V   # system Python interpreter
+    $ python -V   # Homebrew installed Python 3 interpreter (if installed)
     $ python2 -V  # Homebrew installed Python 2 interpreter
     $ python3 -V  # Homebrew installed Python 3 interpreter (if installed)
 
@@ -107,7 +107,7 @@ and is actively maintained.
 .. code-block:: console
 
     $ pip2 -V  # pip pointing to the Homebrew installed Python 2 interpreter
-    $ pip3 -V  # pip pointing to the Homebrew installed Python 3 interpreter (if installed)
+    $ pip -V  # pip pointing to the Homebrew installed Python 3 interpreter (if installed)
 
 
 

--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -62,7 +62,7 @@ Now, we can install Python 3:
 
 .. code-block:: console
 
-    $ brew install python3
+    $ brew install python
 
 This will take a minute or two.
 
@@ -70,9 +70,7 @@ This will take a minute or two.
 Pip
 ---
 
-Homebrew installs ``pip3`` for you.
-
-``pip3`` is the alias to ``pip`` pointing to the Homebrew'd Python 3.
+Homebrew installs ``pip`` pointing to the Homebrew'd Python 3 for you.
 
 Working with Python 3
 ---------------------
@@ -85,7 +83,7 @@ version of Python 3 as well.
 
     $ python
 
-will launch the system Python interpreter.
+will launch the homebrew-installed Python 3 interpreter.
 
 .. code-block:: console
 
@@ -100,21 +98,13 @@ will launch the homebrew-installed Python 2 interpreter (if any).
 will launch the homebrew-installed Python 3 interpreter.
 
 If the Homebrew version of Python 2 is installed then ``pip2`` will point to Python 2.
-If the Homebrew version of Python 3 is installed then ``pip3`` will point to Python 3.
+If the Homebrew version of Python 3 is installed then ``pip`` will point to Python 3.
 
-The rest of the guide will assume that ``python`` references Python 3. You can simply choose to always invoke ``python3`` instead, and much is backwards compatible. However, performing the following steps will set Python 3 as the default interpreter for ``python`` in a shell.
+The rest of the guide will assume that ``python`` references Python 3.
 
 .. code-block:: console
 
-    # Do I have a Python 2 problem?
-    $ python --version
-    Python 2.7.10 # Referencing OSX system install
-    $ which python
-    /usr/bin/python # Yup, homebrew's would be in /usr/local/bin
-    
-    # Symlink /usr/local/bin/python to python3
-    $ ln -s /usr/local/bin/python3 /usr/local/bin/python
-    
+    # Do I have a Python 3 installed?
     $ python --version
     Python 3.6.4 # Success! 
     # If you still see 2.7 ensure in PATH /usr/local/bin/ takes pecedence over /usr/bin/


### PR DESCRIPTION
The default __python__ is now Python 3.
* https://docs.brew.sh/Homebrew-and-Python