### PR TITLE
Update Mac OS X references to macOS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,29 +9,29 @@ http://docs.python-guide.org/en/latest/notes/contribute/
 How to test your changes
 ------------------------
 
-The html version of this guide is built with [sphinx](http://www.sphinx-doc.org/en/stable/). You may test your revisions locally by having sphinx installed. You can do this easily with pip (as described in the link).
+The HTML version of this guide is built with [Sphinx](http://www.sphinx-doc.org/en/stable/). You may test your revisions locally by installing Sphinx. You can do this easily with pip (as described in the link).
 
 ``` bash
 pip install --user sphinx
 ```
 
-Then navigate to the directory of the makefile and ```make build``` or ```make html```. Sphinx will then generate the html in a folder called _build/html
+Then navigate to the directory of the makefile and ```make build``` or ```make html```. Sphinx will then generate the HTML in a folder called `_build/html`.
 
-After navigating to this folder, you can then use python's built in webserver to view your changes locally:
+After navigating to this folder, you can then use Python's built in web server to view your changes locally:
 
 ``` bash
 python3 -m http.server
 ```
 
-By default, http.server listens on every ip address bound on your host on port 8000. To bind to a specific one, say, localhost on port 8005:
+By default, `http.server` listens on every IP address bound on your host on port 8000. To bind to a specific one, say, `localhost` on port 8005:
 
 ``` bash
 python3 -m http.server 8005 --bind 127.0.0.1
 ```
 
-Style Guide
+Style guide
 -----------
 
-For all contributions, please follow the `Guide Style Guide`:
+For all contributions, please follow the Guide Style Guide:
 
 http://docs.python-guide.org/en/latest/notes/styleguide/

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -14,10 +14,10 @@ New to Python? Let's properly setup up your Python environment:
     :maxdepth: 1
 
     starting/installation
-    starting/install3/osx
+    starting/install3/macos
     starting/install3/win
     starting/install3/linux
-    starting/install/osx
+    starting/install/macos
     starting/install/win
     starting/install/linux
 
@@ -137,8 +137,3 @@ Contribution notes and legal information (for those interested).
    notes/contribute
    notes/license
    notes/styleguide
-
-
-
-
-

--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -211,7 +211,7 @@ NINJA-IDE
 
 `NINJA-IDE <http://www.ninja-ide.org/>`_ (from the recursive acronym: "Ninja-IDE
 Is Not Just Another IDE") is a cross-platform IDE, specially designed to build
-Python applications, and runs on Linux/X11, Mac OS X and Windows desktop
+Python applications, and runs on Linux/X11, macOS and Windows desktop
 operating systems. Installers for these platforms can be downloaded from the
 website.
 

--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -199,11 +199,11 @@ a class and function browser, and object inspection.
 WingIDE
 -------
 
-`WingIDE <http://wingware.com/>`_ is a Python specific IDE. It runs on Linux,
-Windows and Mac (as an X11 application, which frustrates some Mac users).
+`WingIDE <http://wingware.com/>`_ is a Python-specific IDE. It runs on Linux,
+Windows, and Mac (as an X11 application, which frustrates some Mac users).
 
-WingIDE offers code completion, syntax highlighting, source browser, graphical
-debugger and support for version control systems.
+WingIDE offers code completion, syntax highlighting, source browser, a graphical
+debugger, and support for version control systems.
 
 
 NINJA-IDE

--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -164,8 +164,8 @@ MIT licensed.
 Enthought Canopy
 ----------------
 `Enthought Canopy <https://www.enthought.com/products/canopy/>`_ is a Python
-IDE which is focused towards Scientists and Engineers as it provides pre 
-installed libraries for data analysis. 
+IDE targeted towards scientists and engineers which provides pre-installed
+libraries for data analysis.
 
 Eclipse
 -------

--- a/docs/dev/pip-virtualenv.rst
+++ b/docs/dev/pip-virtualenv.rst
@@ -39,7 +39,7 @@ environment is needed to install packages.
     Could not find an activated virtualenv (required).
 
 You can also do this configuration by editing your :file:`pip.conf` or
-:file:`pip.ini` file. :file:`pip.conf` is used by Unix and Mac OS X operating
+:file:`pip.ini` file. :file:`pip.conf` is used by Unix and macOS operating
 systems and it can be found at:
 
 .. code-block:: console

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -414,7 +414,7 @@ autoenv
 When you ``cd`` into a directory containing a :file:`.env`, `autoenv <https://github.com/kennethreitz/autoenv>`_
 automagically activates the environment.
 
-Install it on Mac OS X using ``brew``:
+Install it on macOS using ``brew``:
 
 .. code-block:: console
 

--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -109,7 +109,7 @@ experienced developers from other languages a crash course on Python.
     `Crash into Python <http://stephensugden.com/crash_into_python/>`_
 
 
-Dive Into Python 3
+Dive into Python 3
 ~~~~~~~~~~~~~~~~~~
 
 Dive Into Python 3 is a good book for those ready to jump in to Python 3. It's
@@ -119,7 +119,7 @@ experience programming in another language.
     `Dive Into Python 3 <http://www.diveintopython3.net/>`_
 
 
-Think Python: How to Think Like a Computer Scientist
+Think Python: How to Think like a Computer Scientist
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Think Python attempts to give an introduction to basic concepts in computer

--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -143,7 +143,7 @@ Python Koans
 
 Python Koans is a port of Edgecase's Ruby Koans.  It uses a test-driven
 approach, q.v. TEST DRIVEN DESIGN SECTION to provide an interactive tutorial
-teaching basic Python concepts.  By fixing assertion statements that fail in a
+teaching basic Python concepts. By fixing assertion statements that fail in a
 test script, this provides sequential steps to learning Python.
 
 For those used to languages and figuring out puzzles on their own, this can be
@@ -170,8 +170,10 @@ no previous programming experience.
 Learn to Program in Python with Codeacademy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A Codeacademy course for the absolute Python beginner. This free and interactive course provides and teaches the basics (and beyond) of Python programming whilst testing the user's knowledge in between progress.
-This course also features a built-in interpreter for receiving instant feedback on your learning.
+A Codeacademy course for the absolute Python beginner. This free and interactive
+course provides and teaches the basics (and beyond) of Python programming whilst
+testing the user's knowledge in between progress. This course also features a
+built-in interpreter for receiving instant feedback on your learning.
 
     `Learn to Program in Python with Codeacademy <http://www.codecademy.com/en/tracks/python>`_
 

--- a/docs/notes/styleguide.rst
+++ b/docs/notes/styleguide.rst
@@ -143,7 +143,7 @@ Externally Linking
 * Avoid using labels such as "click here", "this", etc. preferring
   descriptive labels (SEO worthy) instead.
 
-Linking to Sections in The Guide
+Linking to Sections in the Guide
 --------------------------------
 
 To cross-reference other parts of this documentation, use the `:ref:

--- a/docs/scenarios/gui.rst
+++ b/docs/scenarios/gui.rst
@@ -18,9 +18,9 @@ and the mailing list https://groups.google.com/forum/#!forum/project-camelot
 
 Cocoa
 -----
-.. note:: The Cocoa framework is only available on OS X. Don't pick this if you're writing a cross-platform application!
+.. note:: The Cocoa framework is only available on macOS. Don't pick this if you're writing a cross-platform application!
 
-GTk
+GTK
 ---
 PyGTK provides Python bindings for the GTK+ toolkit. Like the GTK+ library
 itself, it is currently licensed under the GNU LGPL. It is worth noting that
@@ -47,7 +47,7 @@ such as: Mouse, Dual Mouse, TUIO, WiiMote, WM_TOUCH, HIDtouch, Apple's products
 and so on.
 
 Kivy is actively being developed by a community and is free to use. It operates
-on all major platforms (Linux, OSX, Windows, Android).
+on all major platforms (Linux, macOS, Windows, Android).
 
 The main resource for information is the website: http://kivy.org
 

--- a/docs/shipping/freezing.rst
+++ b/docs/shipping/freezing.rst
@@ -44,15 +44,15 @@ Comparison of Freezing Tools
 
 Solutions and platforms/features supported:
 
-=========== ======= ===== ==== ======== ======= ============= ============== ==== =====================
-Solution    Windows Linux OS X Python 3 License One-file mode Zipfile import Eggs pkg_resources support
-=========== ======= ===== ==== ======== ======= ============= ============== ==== =====================
-bbFreeze    yes     yes   yes  no       MIT     no            yes            yes  yes
-py2exe      yes     no    no   yes      MIT     yes           yes            no   no
-pyInstaller yes     yes   yes  yes      GPL     yes           no             yes  no
-cx_Freeze   yes     yes   yes  yes      PSF     no            yes            yes  no
-py2app      no      no    yes  yes      MIT     no            yes            yes  yes
-=========== ======= ===== ==== ======== ======= ============= ============== ==== =====================
+=========== ======= ===== ===== ======== ======= ============= ============== ==== =====================
+Solution    Windows Linux macOS Python 3 License One-file mode Zipfile import Eggs pkg_resources support
+=========== ======= ===== ===== ======== ======= ============= ============== ==== =====================
+bbFreeze    yes     yes   yes   no       MIT     no            yes            yes  yes
+py2exe      yes     no    no    yes      MIT     yes           yes            no   no
+pyInstaller yes     yes   yes   yes      GPL     yes           no             yes  no
+cx_Freeze   yes     yes   yes   yes      PSF     no            yes            yes  no
+py2app      no      no    yes   yes      MIT     no            yes            yes  yes
+=========== ======= ===== ===== ======== ======= ============= ============== ==== =====================
 
 .. note::
     Freezing Python code on Linux into a Windows executable was only once
@@ -152,8 +152,8 @@ Prerequisite is to have installed :ref:`Python, Setuptools and pywin32 dependenc
 - `Manual <https://pyinstaller.readthedocs.io/en/stable/>`_
 
 
-OS X
-----
+macOS
+-----
 
 
 py2app
@@ -196,7 +196,7 @@ Now :code:`script.spec` can be run with :code:`pyinstaller` (instead of using :c
 
   $ pyinstaller script.spec
 
-To create a standalone windowed OS X application, use the :code:`--windowed` option
+To create a standalone windowed macOS application, use the :code:`--windowed` option
 
 .. code-block:: console
 
@@ -204,7 +204,7 @@ To create a standalone windowed OS X application, use the :code:`--windowed` opt
 
 This creates a :code:`script.app` in the :code:`dist` folder. Make sure to use GUI packages in your Python code, like `PyQt <https://riverbankcomputing.com/software/pyqt/intro>`_ or `PySide <http://wiki.qt.io/About-PySide>`_, to control the graphical parts of the app.
 
-There are several options in :code:`script.spec` related to Mac OS X app bundles `here <http://pythonhosted.org/PyInstaller/spec-files.html#spec-file-options-for-a-mac-os-x-bundle>`_. For example, to specify an icon for the app, use the :code:`icon=\path\to\icon.icns` option. 
+There are several options in :code:`script.spec` related to macOS app bundles `here <http://pythonhosted.org/PyInstaller/spec-files.html#spec-file-options-for-a-mac-os-x-bundle>`_. For example, to specify an icon for the app, use the :code:`icon=\path\to\icon.icns` option.
 
 
 Linux

--- a/docs/shipping/freezing.rst
+++ b/docs/shipping/freezing.rst
@@ -14,8 +14,8 @@ Applications such as 'Dropbox', 'Eve Online',  'Civilization IV', and
 BitTorrent clients do this.
 
 The advantage of distributing this way is that your application will "just work",
-even if the user doesn't already have the required version of Python (or any) 
-installed. On Windows, and even on many Linux distributions and OS X, the right
+even if the user doesn't already have the required version of Python (or any)
+installed. On Windows, and even on many Linux distributions and macOS, the right
 version of Python will not already be installed.
 
 Besides, end-user software should always be in an executable format. Files 

--- a/docs/shipping/packaging.rst
+++ b/docs/shipping/packaging.rst
@@ -161,10 +161,10 @@ each distribution's format (e.g. .deb for Debian/Ubuntu, .rpm for Red
 Hat/Fedora, etc) is a fair amount of work. If your code is an application that
 you plan to distribute on other platforms, then you'll also have to create and
 maintain the separate config required to freeze your application for Windows
-and OSX. It would be much less work to simply create and maintain a single
+and macOS. It would be much less work to simply create and maintain a single
 config for one of the cross platform :ref:`freezing tools
 <freezing-your-code-ref>`, which will produce stand-alone executables for all
-distributions of Linux, as well as Windows and OSX.
+distributions of Linux, as well as Windows and macOS.
 
 Creating a distribution package is also problematic if your code is for a
 version of Python that isn't currently supported by a distribution.

--- a/docs/starting/install/macos.rst
+++ b/docs/starting/install/macos.rst
@@ -1,14 +1,14 @@
-.. _install-osx:
+.. _install-macos:
 
-Installing Python 2 on Mac OS X
+Installing Python 2 on macOS
 ===============================
 
 .. image:: https://farm5.staticflickr.com/4268/34435688560_4cc2a7bcbb_k_d.jpg
 
 .. note::
-    Check out our :ref:`guide for installing Python 3 on OS X<install3-osx>`.
+    Check out our :ref:`guide for installing Python 3 on macOS<install3-macos>`.
 
-The latest version of Mac OS X, High Sierra, **comes with Python 2.7 out of the box**.
+The latest version of macOS, High Sierra, **comes with Python 2.7 out of the box**.
 
 You do not need to install or configure anything else to use Python. Having said
 that, I would strongly recommend that you install the tools and libraries
@@ -16,8 +16,8 @@ described in the next section before you start building Python applications for
 real-world use. In particular, you should always install Setuptools, as it makes
 it much easier for you to install and manage other third-party Python libraries.
 
-The version of Python that ships with OS X is great for learning, but it's not
-good for development. The version shipped with OS X may be out of date from the
+The version of Python that ships with macOS is great for learning, but it's not
+good for development. The version shipped with macOS may be out of date from the
 `official current Python release <https://www.python.org/downloads/mac-osx/>`_,
 which is considered the stable production version.
 
@@ -35,21 +35,21 @@ minimal but unofficial
 package.
 
 .. note::
-    If you already have XCode installed, do not install OSX-GCC-Installer.
+    If you already have Xcode installed, do not install OSX-GCC-Installer.
     In combination, the software can cause issues that are difficult to
     diagnose.
 
 .. note::
-    If you perform a fresh install of XCode, you will also need to add the
+    If you perform a fresh install of Xcode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
 
 
-While OS X comes with a large number of UNIX utilities, those familiar with
+While macOS comes with a large number of UNIX utilities, those familiar with
 Linux systems will notice one key component missing: a decent package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 
 To `install Homebrew <http://brew.sh/#install>`_, open :file:`Terminal` or
-your favorite OSX terminal emulator and run
+your favorite macOS terminal emulator and run
 
 .. code-block:: console
 

--- a/docs/starting/install3/macos.rst
+++ b/docs/starting/install3/macos.rst
@@ -1,19 +1,19 @@
 :orphan: This article should not be added to a toctree for now
 
-.. _install3-osx:
+.. _install3-macos:
 
-Installing Python 3 on Mac OS X
+Installing Python 3 on macOS
 ===============================
 
 .. image:: https://farm5.staticflickr.com/4276/34435689480_2e6f358510_k_d.jpg
 
-The latest version of Mac OS X, High Sierra, **comes with Python 2.7 out of the box**.
+The latest version of macOS, High Sierra, **comes with Python 2.7 out of the box**.
 
 You do not need to install or configure anything else to use Python 2. These
 instructions document the installation of Python 3.
 
-The version of Python that ships with OS X is great for learning, but it's not
-good for development. The version shipped with OS X may be out of date from the
+The version of Python that ships with macOS is great for learning, but it's not
+good for development. The version shipped with macOS may be out of date from the
 `official current Python release <https://www.python.org/downloads/mac-osx/>`_,
 which is considered the stable production version.
 
@@ -23,26 +23,26 @@ Doing it Right
 Let's install a real version of Python.
 
 Before installing Python, you'll need to install GCC. GCC can be obtained
-by downloading `XCode <http://developer.apple.com/xcode/>`_, the smaller
+by downloading `Xcode <http://developer.apple.com/xcode/>`_, the smaller
 `Command Line Tools <https://developer.apple.com/downloads/>`_ (must have an
 Apple account) or the even smaller `OSX-GCC-Installer <https://github.com/kennethreitz/osx-gcc-installer#readme>`_
 package.
 
 .. note::
-    If you already have XCode installed, do not install OSX-GCC-Installer.
+    If you already have Xcode installed, do not install OSX-GCC-Installer.
     In combination, the software can cause issues that are difficult to
     diagnose.
 
 .. note::
-    If you perform a fresh install of XCode, you will also need to add the
+    If you perform a fresh install of Xcode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
 
-While OS X comes with a large number of UNIX utilities, those familiar with
+While macOS comes with a large number of UNIX utilities, those familiar with
 Linux systems will notice one key component missing: a package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 
 To `install Homebrew <http://brew.sh/#install>`_, open :file:`Terminal` or
-your favorite OSX terminal emulator and run
+your favorite macOS terminal emulator and run
 
 .. code-block:: console
 
@@ -76,26 +76,26 @@ Working with Python 3
 ---------------------
 
 At this point, you have the system Python 2.7 available, potentially the
-:ref:`Homebrew version of Python 2 <install-osx>` installed, and the Homebrew
+:ref:`Homebrew version of Python 2 <install-macos>` installed, and the Homebrew
 version of Python 3 as well.
 
 .. code-block:: console
 
     $ python
 
-will launch the homebrew-installed Python 3 interpreter.
+will launch the Homebrew-installed Python 3 interpreter.
 
 .. code-block:: console
 
     $ python2
 
-will launch the homebrew-installed Python 2 interpreter (if any).
+will launch the Homebrew-installed Python 2 interpreter (if any).
 
 .. code-block:: console
 
     $ python3
 
-will launch the homebrew-installed Python 3 interpreter.
+will launch the Homebrew-installed Python 3 interpreter.
 
 If the Homebrew version of Python 2 is installed then ``pip2`` will point to Python 2.
 If the Homebrew version of Python 3 is installed then ``pip`` will point to Python 3.
@@ -106,15 +106,15 @@ The rest of the guide will assume that ``python`` references Python 3.
 
     # Do I have a Python 3 installed?
     $ python --version
-    Python 3.6.4 # Success! 
+    Python 3.6.4 # Success!
     # If you still see 2.7 ensure in PATH /usr/local/bin/ takes pecedence over /usr/bin/
 
 Pipenv & Virtual Environments
 -----------------------------
 
-The next step is to install Pipenv, so you can install dependencies and manage virtual environments. 
+The next step is to install Pipenv, so you can install dependencies and manage virtual environments.
 
-A Virtual Environment is a tool to keep the dependencies required by different projects
+A virtual environment is a tool to keep the dependencies required by different projects
 in separate places, by creating virtual Python environments for them. It solves the
 "Project X depends on version 1.x but, Project Y needs 4.x" dilemma, and keeps
 your global site-packages directory clean and manageable.

--- a/docs/starting/install3/win.rst
+++ b/docs/starting/install3/win.rst
@@ -6,7 +6,7 @@ Installing Python 3 on Windows
 .. image:: https://farm5.staticflickr.com/4276/34435689480_2e6f358510_k_d.jpg
 
 First, follow the installation instructions for `Chocolatey <https://chocolatey.org/install>`_.
-It's a community system packager manager for Windows 7+. (It's very much like Homebrew on OSX.)
+It's a community system packager manager for Windows 7+. (It's very much like Homebrew on macOS.)
 
 Once done, installing Python 3 is very simple, because Chocolatey pushes Python 3 as the default.
 

--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -27,13 +27,13 @@ for development purposes, as well as setuptools, pip and virtualenv.
 Python 3 Installation Guides
 ////////////////////////////
 
-- :ref:`Python 3 on MacOS <install3-osx>`.
+- :ref:`Python 3 on MacOS <install3-macos>`.
 - :ref:`Python 3 on Windows <install3-windows>`.
 - :ref:`Python 3 on Linux <install3-linux>`.
 
 Legacy Python 2 Installation Guides
 ///////////////////////////////////
 
-- :ref:`Python 2 on MacOS <install-osx>`.
+- :ref:`Python 2 on MacOS <install-macos>`.
 - :ref:`Python 2 on Microsoft Windows <install-windows>`.
 - :ref:`Python 2 on Linux <install-linux>`.

--- a/docs/starting/which-python.rst
+++ b/docs/starting/which-python.rst
@@ -136,7 +136,7 @@ inverse approach to that taken by IronPython (see above), to which it
 is more complementary than competing with.
 
 In conjunction with Mono, pythonnet enables native Python
-installations on non-Windows operating systems, such as OS X and
+installations on non-Windows operating systems, such as macOS and
 Linux, to operate within the .NET framework.  It can be run in
 addition to IronPython without conflict.
 


### PR DESCRIPTION
This PR updates references to Mac OS X to the new name of macOS. It also makes some minor style and grammar edits.

Thanks for an awesome guide and hope these changes are helpful!