### PR TITLE
Remove non-contextual embedded video.

### DIFF
--- a/docs/writing/reading.rst
+++ b/docs/writing/reading.rst
@@ -10,14 +10,6 @@ one thing that Python programmers do is read code.
 One of the secrets of becoming a great Python programmer is to read,
 understand, and comprehend excellent code.
 
-.. raw:: html
-
-    <iframe width="560" 
-            height="315" 
-            src="https://www.youtube.com/embed/Jc8M9-LoEuo" 
-            frameborder="0" allowfullscreen></iframe>
-
-
 Excellent code typically follows the guidelines outlined in
 :ref:`code_style`, and does its best to express a clear and concise
 intent to the reader.


### PR DESCRIPTION
Remove a non-contextual embedded video that itself has multiple errors.  It confuses things, at best.