### PR TITLE
Removing pycrypto (package unmaintained + CVE)

### DIFF
--- a/docs/scenarios/crypto.rst
+++ b/docs/scenarios/crypto.rst
@@ -91,32 +91,3 @@ Example
 	    pass
 
 
-
-********
-PyCrypto
-********
-
-`PyCrypto <https://www.dlitz.net/software/pycrypto/>`_ is another library,
-which provides secure hash functions and various encryption algorithms. It
-supports Python version 2.1 through 3.3.
-
-Installation
-~~~~~~~~~~~~
-
-.. code-block:: console
-
-    $ pip install pycrypto
-
-Example
-~~~~~~~
-
-.. code-block:: python
-
-	from Crypto.Cipher import AES
-	# Encryption
-	encryption_suite = AES.new('This is a key123', AES.MODE_CBC, 'This is an IV456')
-	cipher_text = encryption_suite.encrypt("A really secret message. Not for prying eyes.")
-
-	# Decryption
-	decryption_suite = AES.new('This is a key123', AES.MODE_CBC, 'This is an IV456')
-	plain_text = decryption_suite.decrypt(cipher_text)


### PR DESCRIPTION
Unmaintained package with CVE might not be a good help
https://www.cvedetails.com/product/22441/Dlitz-Pycrypto.html?vendor_id=11993

I also share the opinion of the author that pycrypto and its fork may promote insecure usage (like AES::ECB)
https://theartofmachinery.com/2017/02/02/dont_use_pycrypto.html